### PR TITLE
♻️ P2: 코드 품질 개선 (벡터 데드코드, CGV 트랜잭션, 날짜 변환 util)

### DIFF
--- a/apps/article/src/article.service.ts
+++ b/apps/article/src/article.service.ts
@@ -61,7 +61,7 @@ export class ArticleService {
         commentCount: article.comment_count,
         createdAt: article.createdAt.toISOString(),
         updatedAt: article.updatedAt.toISOString(),
-        deletedAt: article.deletedAt?.toISOString() ?? null,
+        deletedAt: this.utilsService.toNullableISOString(article.deletedAt),
       },
     };
   }
@@ -89,7 +89,7 @@ export class ArticleService {
         commentCount: article.comment_count,
         createdAt: article.createdAt.toISOString(),
         updatedAt: article.updatedAt.toISOString(),
-        deletedAt: article.deletedAt?.toISOString() ?? null,
+        deletedAt: this.utilsService.toNullableISOString(article.deletedAt),
       },
     };
   }
@@ -124,7 +124,7 @@ export class ArticleService {
         commentCount: article.comment_count,
         createdAt: article.createdAt.toISOString(),
         updatedAt: article.updatedAt.toISOString(),
-        deletedAt: article.deletedAt?.toISOString() ?? null,
+        deletedAt: this.utilsService.toNullableISOString(article.deletedAt),
       })),
       hasNext,
     };
@@ -171,7 +171,7 @@ export class ArticleService {
         commentCount: article.comment_count,
         createdAt: article.createdAt.toISOString(),
         updatedAt: article.updatedAt.toISOString(),
-        deletedAt: article.deletedAt?.toISOString() ?? null,
+        deletedAt: this.utilsService.toNullableISOString(article.deletedAt),
       },
     };
   }
@@ -343,7 +343,7 @@ export class ArticleService {
         content: comment.content,
         createdAt: comment.createdAt.toISOString(),
         updatedAt: comment.updatedAt.toISOString(),
-        deletedAt: comment.deletedAt?.toISOString() ?? null,
+        deletedAt: this.utilsService.toNullableISOString(comment.deletedAt),
         nickname: comment.User.nickname,
         avatar: comment.User.image,
       })),

--- a/apps/movie/src/movie.service.ts
+++ b/apps/movie/src/movie.service.ts
@@ -178,7 +178,6 @@ export class MovieService implements OnModuleInit {
         }
 
         const vector = [];
-        // const vector = await this.utilsService.generateEmbedding(plot);
 
         await this.mysqlPrismaService.movie.upsert({
           where: { movieCd: +movieData.movieCd },
@@ -402,37 +401,9 @@ export class MovieService implements OnModuleInit {
       averageScore: averageScore,
     } as Omit<MovieData, 'vector'>;
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async recommendMovies(movieCd: number): Promise<any> {
+  async recommendMovies(_movieCd: number): Promise<any> {
+    // TODO: 벡터 유사도 검색 미구현 — Milvus 또는 pgvector 연동 후 활성화
     return [];
-    // const movie = await this.mysqlPrismaService.movie.findUnique({
-    //   where: { movieCd },
-    // });
-    // if (!movie) {
-    //   throw new Error(`Movie with movieCd ${movieCd} not found`);
-    // }
-    // const vector = movie.vector;
-
-    // const similarMovies: { movieCd: number; similarity: number }[] = await this
-    //   .postgresPrismaService.$queryRaw`SELECT "movieCd",
-    // (SELECT SUM(a * b)
-    //  FROM unnest("vector") AS a, unnest(ARRAY[${vector}]) AS b) AS similarity
-    //   FROM public."MovieVector"
-    //   WHERE "movieCd" != ${movieCd}
-    //   ORDER BY similarity DESC
-    //   LIMIT 10;`;
-    // if (!similarMovies) {
-    //   throw new Error('No similar movies found');
-    // }
-
-    // const recommendedMovies = await this.mysqlPrismaService.movie.findMany({
-    //   where: {
-    //     movieCd: {
-    //       in: similarMovies.map((movie) => movie.movieCd),
-    //     },
-    //   },
-    // });
-    // return recommendedMovies;
   }
 
   async getMovieDetail(movieCd: number): Promise<MovieData> {
@@ -696,23 +667,25 @@ export class MovieService implements OnModuleInit {
     try {
       console.log('CGV 영화관 데이터 동기화 시작...');
       const crawledTheaters = await this.crawlingService.getCGVTheaters();
-      console.log(crawledTheaters);
 
-      // 기존 데이터 삭제
-      await this.mysqlPrismaService.cGVTheater.deleteMany();
+      if (!crawledTheaters || crawledTheaters.length === 0) {
+        console.warn('크롤링 결과가 없어 동기화를 건너뜁니다.');
+        return;
+      }
 
-      // 새 데이터 삽입
-      for (const theater of crawledTheaters) {
-        await this.mysqlPrismaService.cGVTheater.create({
-          data: {
+      // 트랜잭션으로 묶어 크롤링 실패 시 기존 데이터 보존
+      await this.mysqlPrismaService.$transaction(async (tx) => {
+        await tx.cGVTheater.deleteMany();
+        await tx.cGVTheater.createMany({
+          data: crawledTheaters.map((theater) => ({
             name: theater.name,
             region: theater.region,
-            address: theater.address,
-            phone: theater.phone,
-            website: theater.website,
-          },
+            address: theater.address ?? null,
+            phone: theater.phone ?? null,
+            website: theater.website ?? null,
+          })),
         });
-      }
+      });
 
       console.log(`CGV 영화관 ${crawledTheaters.length}개 동기화 완료`);
     } catch (error) {

--- a/libs/utils/src/utils.service.ts
+++ b/libs/utils/src/utils.service.ts
@@ -20,6 +20,7 @@ export class UtilsService {
   toNullableISOString(date: Date | null | undefined): string | null {
     return date ? date.toISOString() : null;
   }
+
   async generateEmbedding(description: string): Promise<any> {
     const model = 'sentence-transformers/all-MiniLM-L6-v2';
     const embeddings = await this.hf.featureExtraction({

--- a/libs/utils/src/utils.service.ts
+++ b/libs/utils/src/utils.service.ts
@@ -16,6 +16,10 @@ export class UtilsService {
     timestamp.setNanos((date.getTime() % 1000) * 1000000);
     return timestamp;
   }
+
+  toNullableISOString(date: Date | null | undefined): string | null {
+    return date ? date.toISOString() : null;
+  }
   async generateEmbedding(description: string): Promise<any> {
     const model = 'sentence-transformers/all-MiniLM-L6-v2';
     const embeddings = await this.hf.featureExtraction({


### PR DESCRIPTION
## 작업 내용
- `recommendMovies()`의 미사용 PostgreSQL 벡터 검색 코드 제거 → TODO 주석으로 대체
- CGV 영화관 동기화 로직에 트랜잭션 적용 (`$transaction` + `createMany`)
- `UtilsService`에 `toNullableISOString()` 헬퍼 추가, `article.service.ts`에 적용

## 변경 이유
- 주석 처리된 30줄짜리 PostgreSQL 코드가 현재 스택(MySQL)에서 동작 불가, 유지보수 혼란 유발
- CGV `deleteMany()` 후 개별 `create()` 루프는 중간 실패 시 데이터 전체 소실 위험
- `date?.toISOString() ?? null` 패턴이 여러 서비스에 산재, 일관성 없이 반복

## 테스트 체크리스트
- [ ] `/movie/recommend/:movieCd` API 호출 시 빈 배열 반환 확인
- [ ] CGV 동기화 크롤링 실패 시 기존 데이터 유지 확인
- [ ] article API 응답의 `deletedAt` 필드 null 처리 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)