### PR TITLE
🔧 fix: 워크플로우 Docker 빌드 경로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Build and push ${{ matrix.service }}
         uses: docker/build-push-action@v5
         with:
-          context: ./nest-msa
-          file: ./nest-msa/Dockerfile
+          context: .
+          file: ./Dockerfile
           build-args: APP=${{ matrix.service }}
           target: production
           push: true


### PR DESCRIPTION
## 원인
GitHub Actions는 레포 루트(= `nest-msa/`)에서 실행되는데
워크플로우에서 `context: ./nest-msa`, `file: ./nest-msa/Dockerfile`로 중복 경로를 지정해 빌드 실패.

## 수정
- `context: ./nest-msa` → `context: .`
- `file: ./nest-msa/Dockerfile` → `file: ./Dockerfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)