### PR TITLE
🔧 fix: prisma generate 스키마 경로 명시

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install
 COPY . .
 RUN pnpm run build ${APP}
-RUN npx prisma generate
+RUN npx prisma generate --schema prisma/mysql.schema.prisma
 
 FROM base AS production
 ARG APP


### PR DESCRIPTION
스키마가 기본 경로가 아닌 `prisma/mysql.schema.prisma`여서 빌드 실패. `--schema` 플래그 추가.