### PR TITLE
fix: 서버 배포 경로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
             set -e
 
             echo "▶ 코드 업데이트"
-            cd /app/movie/movie-review-msa/nest-msa
+            cd /app/movie/movie-review-msa
             git pull origin master
 
             echo "▶ GHCR 로그인"


### PR DESCRIPTION
## Summary
- SSH 배포 시 `cd /app/movie/movie-review-msa/nest-msa` → `cd /app/movie/movie-review-msa` 경로 수정
- 서버에 `nest-msa` 하위 폴더가 없어 배포 실패하던 문제 해결

## Test plan
- [ ] GitHub Actions 배포 잡이 정상 실행되는지 확인
- [ ] `docker compose -f docker-compose.prod.yml up -d` 서비스 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)