### PR TITLE
fix: MySQL 포트 충돌 해결 및 배포 경로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,14 @@ jobs:
               api-gateway \
               sh -c "prisma migrate deploy --schema prisma/mysql.schema.prisma"
 
+            echo "▶ MySQL 상태 확인 (실행 중이 아닐 때만 시작)"
+            if ! docker ps --format '{{.Names}}' | grep -q "^mysql$"; then
+              docker compose -f docker-compose.prod.yml --profile db up -d mysql
+            fi
+
+            echo "▶ MySQL을 app-network에 연결"
+            docker network connect nest-msa_app-network mysql 2>/dev/null || true
+
             echo "▶ 서비스 재시작"
             docker compose -f docker-compose.prod.yml up -d
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,8 @@ services:
   mysql:
     image: mysql:8.0
     container_name: mysql
+    profiles:
+      - db
     ports:
       - '3306:3306'
     volumes:
@@ -35,8 +37,6 @@ services:
       - .env.production
     networks:
       - app-network
-    depends_on:
-      - mysql
     restart: unless-stopped
 
   auth-service:
@@ -50,9 +50,6 @@ services:
       - .env.production
     networks:
       - app-network
-    depends_on:
-      - mysql
-      - api-gateway
     restart: unless-stopped
     command:
       - bash
@@ -72,9 +69,6 @@ services:
       - .env.production
     networks:
       - app-network
-    depends_on:
-      - mysql
-      - api-gateway
     restart: unless-stopped
     command:
       - bash
@@ -94,9 +88,6 @@ services:
       - .env.production
     networks:
       - app-network
-    depends_on:
-      - mysql
-      - api-gateway
     restart: unless-stopped
     command:
       - bash
@@ -116,9 +107,6 @@ services:
       - .env.production
     networks:
       - app-network
-    depends_on:
-      - mysql
-      - api-gateway
     restart: unless-stopped
     command:
       - bash
@@ -138,9 +126,6 @@ services:
       - .env.production
     networks:
       - app-network
-    depends_on:
-      - mysql
-      - api-gateway
     restart: unless-stopped
     command:
       - bash
@@ -161,9 +146,6 @@ services:
       - .env.production
     networks:
       - app-network
-    depends_on:
-      - mysql
-      - api-gateway
     restart: unless-stopped
 
   match-service:
@@ -177,9 +159,6 @@ services:
       - .env.production
     networks:
       - app-network
-    depends_on:
-      - mysql
-      - api-gateway
     restart: unless-stopped
     command:
       - bash
@@ -199,9 +178,6 @@ services:
       - .env.production
     networks:
       - app-network
-    depends_on:
-      - mysql
-      - api-gateway
     restart: unless-stopped
     command:
       - bash


### PR DESCRIPTION
## Summary
- MySQL이 이미 실행 중일 때 포트 3306 충돌 오류 해결
- `mysql` 서비스에 `profiles: [db]` 추가 — 기본 `up -d` 시 제외됨
- 배포 스크립트에서 mysql 컨테이너 실행 여부 확인 후 조건부 시작
- 기존 mysql 컨테이너를 `app-network`에 자동 연결
- 앱 서비스에서 `depends_on: mysql` 제거 (wait-for-it이 실제 대기 담당)

## Test plan
- [ ] MySQL이 이미 실행 중인 상태에서 배포 시 포트 충돌 없이 성공하는지 확인
- [ ] MySQL이 없는 상태에서 배포 시 자동으로 mysql 컨테이너 시작되는지 확인
- [ ] 앱 서비스들이 mysql에 정상 연결되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)