### PR TITLE
🐛 Prisma Client를 linux-musl 대상으로 빌드

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+prisma/generated
 .git
 .github
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR /usr/src/app
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --prod
 COPY --from=development /usr/src/app/dist ./dist
+COPY --from=development /usr/src/app/prisma/generated ./prisma/generated
 
 ENV APP_MAIN_FILE=dist/apps/${APP}/src/main
 CMD node ${APP_MAIN_FILE}


### PR DESCRIPTION
## Summary
서버의 auth/user/movie/match/reply/article/chat 7개 MSA가 6일째 재시작 루프.

**로그:**
> Prisma Client was generated for "darwin-arm64", but the actual deployment required "linux-musl"

**원인:**
- base 스테이지의 `COPY prisma ./prisma`가 맥 로컬에서 생성된 `prisma/generated/mysql`(darwin-arm64 바이너리 포함)을 이미지로 끌어옴
- development 스테이지의 `prisma generate`가 Linux에서 제대로 돌아도, production 스테이지는 `dist`만 복사하므로 base에 박힌 맥 바이너리를 런타임에 로드

**수정:**
- `.dockerignore`에 `prisma/generated` 추가 → 맥 아티팩트가 빌드 컨텍스트에 들어가지 않도록 차단
- `Dockerfile` production 스테이지에 `COPY --from=development /usr/src/app/prisma/generated ./prisma/generated` 추가 → 런타임에는 Linux에서 생성된 바이너리만 사용

## Test plan
- [ ] develop→master 릴리스 후 CI 빌드 성공
- [ ] 서버의 MSA 7개 모두 `Up` 상태로 전환
- [ ] `docker logs auth-service` 에 Prisma 에러 사라짐
- [ ] api-gateway 경유 `/auth/login`, `/movie` 등 응답 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)