### PR TITLE
🐛 fix: Prisma generate를 build 이전으로 이동

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ WORKDIR /usr/src/app
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install
 COPY . .
-RUN pnpm run build ${APP}
 RUN npx prisma generate --schema prisma/mysql.schema.prisma
+RUN pnpm run build ${APP}
 
 FROM base AS production
 ARG APP


### PR DESCRIPTION
## Summary
- TypeScript 빌드가 Prisma 타입을 필요로 하므로 `npx prisma generate`를 `pnpm run build` 이전 단계로 이동
- 이전 PR #16에서 `.dockerignore`에 `prisma/generated` 추가 후, Mac 생성 타입이 더이상 컨텍스트에 포함되지 않아 TypeScript 컴파일이 실패하던 문제 해결

## Background
PR #16이 런타임 바이너리 불일치(darwin-arm64 vs linux-musl)는 해결했지만,
Dockerfile에서 `prisma generate`가 `build` 뒤에 있어 TS 컴파일 단계에서 타입이 없어 실패.
Mac에서 생성된 타입이 이전까지는 우연히 빌드 성공을 만들어 줬음.

## Test plan
- [ ] GitHub Actions 빌드가 9개 서비스 모두 성공하는지 확인
- [ ] 서버 배포 후 컨테이너가 크래시 루프 없이 기동되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)