### PR TITLE
🚀 Release: Prisma generate 순서 교정 반영

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ WORKDIR /usr/src/app
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install
 COPY . .
-RUN pnpm run build ${APP}
 RUN npx prisma generate --schema prisma/mysql.schema.prisma
+RUN pnpm run build ${APP}
 
 FROM base AS production
 ARG APP


### PR DESCRIPTION
## Summary
- PR #18 머지분 배포 (Dockerfile의 `npx prisma generate`를 `pnpm run build` 이전으로 이동)
- 9개 MSA 서비스의 빌드 실패(`./libs/prisma/src/mysql-prisma.service.ts` TS 컴파일 에러) 해결

## Test plan
- [ ] deploy.yml 매트릭스 빌드가 9개 서비스 모두 성공
- [ ] 서버에서 컨테이너가 재시작 루프 없이 기동
- [ ] api-gateway → MSA gRPC 호출 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)