### PR TITLE
🐛 Prisma binaryTargets에 linux-musl-openssl-3.0.x 추가

### DIFF
--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -1,6 +1,7 @@
 generator client {
-  provider = "prisma-client-js"
-  output   = "./generated/mysql"
+  provider      = "prisma-client-js"
+  output        = "./generated/mysql"
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- Alpine 3.17+ 기반 컨테이너(`node:18-alpine`)는 OpenSSL 3을 사용하는데 Prisma 기본 `linux-musl` 엔진은 `libssl.so.1.1`(OpenSSL 1.1)을 요구해 런타임 로딩 실패
- `binaryTargets = ["native", "linux-musl-openssl-3.0.x"]` 추가로 OpenSSL 3용 엔진 바이너리도 생성되도록 수정

## Error log
```
Error loading shared library libssl.so.1.1: No such file or directory
(needed by /usr/src/app/prisma/generated/mysql/libquery_engine-linux-musl.so.node)
```

## Test plan
- [ ] `docker compose build` 후 재기동 시 movie 서비스가 정상적으로 gRPC listen 하는지 확인
- [ ] 다른 서비스(auth/user/reply/article/match/chat/cron)도 동일 스키마 사용하므로 함께 정상 기동 확인
- [ ] Prisma 쿼리 실제 DB 조회 정상 동작 확인