### PR TITLE
🚀 Release: Prisma OpenSSL 3 엔진 타겟 추가

### DIFF
--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -1,6 +1,7 @@
 generator client {
-  provider = "prisma-client-js"
-  output   = "./generated/mysql"
+  provider      = "prisma-client-js"
+  output        = "./generated/mysql"
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- Alpine OpenSSL 3 런타임 호환을 위해 Prisma `binaryTargets`에 `linux-musl-openssl-3.0.x` 추가 (#20)

## Deploy trigger
master push → GHCR 빌드 → SSH 배포

## Test plan
- [ ] Actions 빌드·배포 성공
- [ ] movie 등 마이크로서비스 기동 시 Prisma 엔진 정상 로드
- [ ] DB 쿼리 동작 확인