### PR TITLE
🐳 Alpine 이미지에 openssl CLI 설치 (Prisma OpenSSL 탐지 수정)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN wget http://cdn.naver.com/naver/NanumFont/fontfiles/NanumFont_TTF_ALL.zip
 RUN unzip NanumFont_TTF_ALL.zip -d /usr/share/fonts/nanumfont
 RUN fc-cache -f && rm -rf /var/cache/*
 
-RUN apk add bash
+RUN apk add --no-cache bash openssl
 
 ENV LANG=ko_KR.UTF-8 \
     LANGUAGE=ko_KR.UTF-8


### PR DESCRIPTION
## Summary
- `node:18-alpine`에는 libssl3는 있지만 `openssl` CLI가 없어 Prisma 런타임 버전 탐지가 실패
- 탐지 실패 시 기본값 `linux-musl` (OpenSSL 1.1) 엔진으로 폴백 → `libssl.so.1.1` 로딩 에러
- `apk add openssl`로 CLI 설치해 정상 탐지되도록 수정

## 관련 PR
- #20 — binaryTargets에 linux-musl-openssl-3.0.x 추가 (엔진 바이너리는 이미 이미지에 생성됨)

## Test plan
- [ ] Actions 배포 성공
- [ ] movie 등 마이크로서비스 정상 기동, Prisma 엔진 로드 에러 없음
- [ ] DB 쿼리 동작 확인