### PR TITLE
🐛 chat nest-cli 설정을 다른 앱과 통일 (MODULE_NOT_FOUND 수정)

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -118,10 +118,12 @@
     "chat": {
       "type": "application",
       "root": "apps/chat",
-      "entryFile": "main",
-      "sourceRoot": "apps/chat/src",
+      "entryFile": "src/main",
+      "sourceRoot": "./",
       "compilerOptions": {
-        "tsConfigPath": "apps/chat/tsconfig.app.json"
+        "tsConfigPath": "apps/chat/tsconfig.app.json",
+        "assets": ["proto/*.proto"],
+        "watchAssets": true
       }
     },
     "match": {


### PR DESCRIPTION
## Summary
- chat만 \`entryFile=main\`, \`sourceRoot=apps/chat/src\` 로 설정돼 빌드 결과가 \`dist/apps/chat/main.js\`에 생성됨
- Dockerfile은 전 서비스에 대해 \`dist/apps/\${APP}/src/main\` 실행 → chat 컨테이너 MODULE_NOT_FOUND
- 다른 앱과 동일하게 \`entryFile=src/main\`, \`sourceRoot=./\` 로 맞추고 proto assets 설정 추가

## Test plan
- [ ] 배포 후 chat 컨테이너 정상 기동
- [ ] WebSocket 3031 / gRPC 50057 정상 리슨