### PR TITLE
🚀 Release: chat nest-cli 경로 수정

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -118,10 +118,12 @@
     "chat": {
       "type": "application",
       "root": "apps/chat",
-      "entryFile": "main",
-      "sourceRoot": "apps/chat/src",
+      "entryFile": "src/main",
+      "sourceRoot": "./",
       "compilerOptions": {
-        "tsConfigPath": "apps/chat/tsconfig.app.json"
+        "tsConfigPath": "apps/chat/tsconfig.app.json",
+        "assets": ["proto/*.proto"],
+        "watchAssets": true
       }
     },
     "match": {


### PR DESCRIPTION
## Summary
- #24 — chat nest-cli 설정 통일로 MODULE_NOT_FOUND 해결

## Test plan
- [ ] chat 컨테이너 정상 기동