### PR TITLE
🐛 chat protoPath를 다른 앱과 동일 규칙으로 정정

### DIFF
--- a/apps/chat/src/main.ts
+++ b/apps/chat/src/main.ts
@@ -12,7 +12,7 @@ async function bootstrap() {
     {
       transport: Transport.GRPC,
       options: {
-        protoPath: join(__dirname, '../../../proto/chat.proto'),
+        protoPath: join(__dirname, '../chat.proto'),
         package: CHAT_PACKAGE_NAME,
         url: `0.0.0.0:${process.env.CHAT_GRPC_PORT || '50057'}`,
       },


### PR DESCRIPTION
## Summary
- chat만 \`join(__dirname, '../../../proto/chat.proto')\` 로 \`dist/proto/chat.proto\`를 참조 — 실제 asset 복사 규칙은 \`dist/apps/chat/chat.proto\`에 파일 배치
- movie/auth 등 다른 앱과 동일하게 \`../chat.proto\`로 수정

## Test plan
- [ ] chat 컨테이너 기동 후 gRPC 50057 정상 리슨, InvalidProtoDefinitionException 없음