### PR TITLE
🐛 cron 스케줄·중복 호출 수정

### DIFF
--- a/apps/cron/src/cron.service.ts
+++ b/apps/cron/src/cron.service.ts
@@ -4,11 +4,9 @@ import { MovieService } from './movie/movie.service';
 
 @Injectable()
 export class CronService {
-  constructor(private readonly movieService: MovieService) {
-    this.movieService.fetchMoviedata();
-  }
+  constructor(private readonly movieService: MovieService) {}
 
-  @Cron('* 10 0 * * *')
+  @Cron('0 10 0 * * *')
   handleCron() {
     this.movieService.fetchMoviedata();
   }


### PR DESCRIPTION
## Summary
- \`CronService\` 생성자에서 즉시 \`fetchMoviedata()\` 호출 제거 — \`MovieService.onModuleInit\` 과 중복
- \`@Cron('* 10 0 * * *')\` → \`@Cron('0 10 0 * * *')\` — 초 필드 \`*\` 로 인해 00:10:00~00:10:59 매 초 실행되어 60회 중복 호출되던 이슈 해결

## Context
홈페이지 박스오피스 목록 누락 이슈 진단 중 발견된 부수 버그. 주 원인은 서버 .env.production 환경변수 이름 불일치(MOVIE_SECRET → KOFIC_API_KEY)이며 그쪽은 서버 직접 수정.

## Test plan
- [ ] 배포 후 \`docker logs cron --since=24h\` 로 매일 00:10 부근 실행이 1회만 기록되는지 확인
- [ ] movie 서비스 부팅 시 \`No daily box office list...\` 경고가 1회만 (또는 env 정상화 후 0회) 출력되는지 확인