### PR TITLE
🐛 영화 메타데이터 upsert·검색 정확도 개선

### DIFF
--- a/apps/movie/src/movie.service.ts
+++ b/apps/movie/src/movie.service.ts
@@ -75,11 +75,11 @@ export class MovieService implements OnModuleInit {
 
     // const lastYear = moment().subtract(1, 'years').format('YYYY') + '0101';
     const thisYear = moment().format('YYYY') + '0101';
-    let url = `${this.kmdbUrl}?collection=kmdb_new2&ServiceKey=${this.kmdbKey}&detail=Y&title=${title}&sort=prodYear,1&releaseDts=${thisYear}`;
+    let url = `${this.kmdbUrl}?collection=kmdb_new2&ServiceKey=${this.kmdbKey}&detail=Y&title=${title}&sort=prodYear,0&releaseDts=${thisYear}`;
     let response = await axios.get<KmdbResponse>(url);
 
     if (!response.data?.Data?.[0]?.Result?.[0]) {
-      url = `${this.kmdbUrl}?collection=kmdb_new2&ServiceKey=${this.kmdbKey}&detail=Y&title=${title}&sort=prodYear,1`;
+      url = `${this.kmdbUrl}?collection=kmdb_new2&ServiceKey=${this.kmdbKey}&detail=Y&title=${title}&sort=prodYear,0`;
       response = await axios.get<KmdbResponse>(url);
 
       if (!response.data?.Data?.[0]?.Result?.[0]) {
@@ -165,11 +165,13 @@ export class MovieService implements OnModuleInit {
           }
 
           const tmdbData = await this.fetchTmdbData(movieData.movieNm);
-          if (tmdbData) {
+          if (tmdbData?.poster_path) {
             poster = `https://image.tmdb.org/t/p/w500${tmdbData.poster_path}`;
-            plot = tmdbData.overview;
-          } else if (fetchedData) {
+          } else if (!poster && fetchedData) {
             poster = fetchedData.posters?.split('|')?.[0] ?? '';
+          }
+          if (tmdbData?.overview) {
+            plot = tmdbData.overview;
           }
         } catch (error) {
           console.warn(`fetchKmdbData failed for ${movieData.movieNm}:`, error);
@@ -185,6 +187,11 @@ export class MovieService implements OnModuleInit {
             updatedAt: new Date(),
             rankInten: movieData.rankInten,
             rankOldAndNew: movieData.rankOldAndNew,
+            ...(poster && { poster }),
+            ...(plot && { plot }),
+            ...(director && { director }),
+            ...(genre && { genre }),
+            ...(rating && { ratting: rating }),
           },
           create: {
             title: movieData.movieNm,


### PR DESCRIPTION
## Summary
'마녀배달부 키키', '쉘터' 등 일부 영화의 포스터·줄거리가 빈 채로 저장되는 문제 수정.

## 원인
1. **upsert UPDATE 블록 누락**: `movie.service.ts:182-188` 이 poster/plot/director/genre/ratting 을 갱신하지 않아, 과거에 빈 값으로 생성된 레코드가 외부 API 복구 후에도 영원히 빈 상태.
2. **TMDB 덮어쓰기 사고**: TMDB 응답에 `overview: ""` 가 있으면 KMDB 에서 받은 plot 을 빈 문자열로 덮어씀. `poster_path: null` 이면 `/w500null` 깨진 URL 생성.
3. **KMDB 정렬 역방향**: `sort=prodYear,1` (오름차순) 탓에 "쉘터" 같은 동명이작에서 가장 오래된 영화가 선택됨. 박스오피스 영화는 최신작 확률이 압도적이므로 내림차순이 자연스러움.

## 변경
- `update` 블록에 조건부 spread 로 5 개 메타 필드 추가 (`poster && { poster }` 형태 — truthy 일 때만 덮어쓰기)
- TMDB 분기: `poster_path` 유무로 poster 덮어쓰기 판단, `overview` 유무로 plot 덮어쓰기 판단
- KMDB URL 두 곳 `sort=prodYear,0` 으로 변경

## Test plan
- [ ] 머지·배포 후 `docker logs movie --tail=100` 에 `fetchKmdbData failed` 없음
- [ ] MySQL: `SELECT title, poster, plot FROM Movie WHERE updatedAt >= CURDATE()` → 전 10행 모두 poster/plot 비어있지 않음
- [ ] 기존 빈 레코드 백필: `UPDATE Movie SET updatedAt = '2000-01-01' WHERE poster = '' OR plot = ''` 후 movie 컨테이너 재기동 → onModuleInit 이 재조회해서 UPDATE 경로로 채움
- [ ] 홈 `/` 에서 '마녀배달부 키키', '쉘터' 등 포스터·줄거리 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)