### PR TITLE
🚀 Release: 영화 메타데이터 upsert·검색 개선

### DIFF
--- a/apps/movie/src/movie.service.ts
+++ b/apps/movie/src/movie.service.ts
@@ -75,11 +75,11 @@ export class MovieService implements OnModuleInit {
 
     // const lastYear = moment().subtract(1, 'years').format('YYYY') + '0101';
     const thisYear = moment().format('YYYY') + '0101';
-    let url = `${this.kmdbUrl}?collection=kmdb_new2&ServiceKey=${this.kmdbKey}&detail=Y&title=${title}&sort=prodYear,1&releaseDts=${thisYear}`;
+    let url = `${this.kmdbUrl}?collection=kmdb_new2&ServiceKey=${this.kmdbKey}&detail=Y&title=${title}&sort=prodYear,0&releaseDts=${thisYear}`;
     let response = await axios.get<KmdbResponse>(url);
 
     if (!response.data?.Data?.[0]?.Result?.[0]) {
-      url = `${this.kmdbUrl}?collection=kmdb_new2&ServiceKey=${this.kmdbKey}&detail=Y&title=${title}&sort=prodYear,1`;
+      url = `${this.kmdbUrl}?collection=kmdb_new2&ServiceKey=${this.kmdbKey}&detail=Y&title=${title}&sort=prodYear,0`;
       response = await axios.get<KmdbResponse>(url);
 
       if (!response.data?.Data?.[0]?.Result?.[0]) {
@@ -165,11 +165,13 @@ export class MovieService implements OnModuleInit {
           }
 
           const tmdbData = await this.fetchTmdbData(movieData.movieNm);
-          if (tmdbData) {
+          if (tmdbData?.poster_path) {
             poster = `https://image.tmdb.org/t/p/w500${tmdbData.poster_path}`;
-            plot = tmdbData.overview;
-          } else if (fetchedData) {
+          } else if (!poster && fetchedData) {
             poster = fetchedData.posters?.split('|')?.[0] ?? '';
+          }
+          if (tmdbData?.overview) {
+            plot = tmdbData.overview;
           }
         } catch (error) {
           console.warn(`fetchKmdbData failed for ${movieData.movieNm}:`, error);
@@ -185,6 +187,11 @@ export class MovieService implements OnModuleInit {
             updatedAt: new Date(),
             rankInten: movieData.rankInten,
             rankOldAndNew: movieData.rankOldAndNew,
+            ...(poster && { poster }),
+            ...(plot && { plot }),
+            ...(director && { director }),
+            ...(genre && { genre }),
+            ...(rating && { ratting: rating }),
           },
           create: {
             title: movieData.movieNm,


### PR DESCRIPTION
## Summary
- 영화 메타데이터 upsert 누락·검색 오매칭 수정 (PR #30)
  - upsert UPDATE 블록에 poster/plot/director/genre/ratting 추가 (truthy 일 때만)
  - TMDB `poster_path`/`overview` 유무 확인 후 덮어쓰기
  - KMDB 정렬 `prodYear` 내림차순으로 변경

## Deploy
master push → GHCR 빌드 → SSH 배포 자동 수행.

## Post-deploy
서버에서 기존 빈 레코드 백필 필요:
```sql
UPDATE Movie SET updatedAt = '2000-01-01' WHERE poster = '' OR plot = '';
```
이후 `docker compose restart movie` → onModuleInit 이 재조회해서 UPDATE 경로로 채움.

🤖 Generated with [Claude Code](https://claude.com/claude-code)