### PR TITLE
♻️ console.log → NestJS Logger 전환 및 환경별 로그 레벨 설정

### DIFF
--- a/apps/api-gateway/src/article/article.controller.ts
+++ b/apps/api-gateway/src/article/article.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  Logger,
   Param,
   Patch,
   Post,
@@ -20,6 +21,7 @@ import {
 import { JwtAuthGuard } from '@app/common/guards/jwtauth/jwtauth.guard';
 @Controller('article')
 export class ArticleController {
+  private readonly logger = new Logger(ArticleController.name);
   constructor(private readonly articleService: ArticleService) {}
   @Post()
   @UseGuards(JwtAuthGuard)
@@ -31,7 +33,7 @@ export class ArticleController {
 
   @Get(':id')
   async getArticle(@Param('id') id: string) {
-    console.log('getArticle id', id);
+    this.logger.debug(`getArticle id=${id}`);
     return this.articleService.getArticle({ id: Number(id) });
   }
 
@@ -40,7 +42,7 @@ export class ArticleController {
     @Query('page') page: string,
     @Query('pageSize') pageSize: string,
   ) {
-    console.log('page', page, 'pageSize', pageSize);
+    this.logger.debug(`listArticles page=${page} pageSize=${pageSize}`);
     return this.articleService.listArticles({
       page: Number(page) || 1,
       pageSize: Number(pageSize) || 10,
@@ -129,7 +131,7 @@ export class ArticleController {
   ) {
     const userNumber = req.user.userId;
     body.userno = userNumber;
-    console.log('likeArticle body', body);
+    this.logger.debug(`likeArticle articleId=${articleId} state=${body.state}`);
     return this.articleService.likeArticle({
       articleId: Number(articleId),
       ...body,

--- a/apps/api-gateway/src/auth/auth.service.ts
+++ b/apps/api-gateway/src/auth/auth.service.ts
@@ -3,11 +3,12 @@ import {
   AUTH_SERVICE_NAME,
   AUTH_PACKAGE_NAME,
 } from '@app/common/protobuf';
-import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ClientGrpc } from '@nestjs/microservices';
 
 @Injectable()
 export class AuthService implements OnModuleInit {
+  private readonly logger = new Logger(AuthService.name);
   private authService: AuthServiceClient;
   constructor(
     @Inject(AUTH_PACKAGE_NAME)
@@ -20,7 +21,7 @@ export class AuthService implements OnModuleInit {
 
   login({ email, password }: { email: string; password: string }) {
     if (!this.authService) {
-      console.log('Auth service is not initialized.');
+      this.logger.error('Auth service is not initialized.');
       return;
     }
     return this.authService.loginUser({ email, password });
@@ -33,7 +34,7 @@ export class AuthService implements OnModuleInit {
     accessToken: string;
   }) {
     if (!this.authService) {
-      console.log('Auth service is not initialized.');
+      this.logger.error('Auth service is not initialized.');
       return;
     }
     return this.authService.oauthLogin({
@@ -44,7 +45,7 @@ export class AuthService implements OnModuleInit {
 
   validateEmail({ email }: { email: string }) {
     if (!this.authService) {
-      console.log('Auth service is not initialized.');
+      this.logger.error('Auth service is not initialized.');
       return;
     }
     return this.authService.validateEmail({ email });
@@ -52,7 +53,7 @@ export class AuthService implements OnModuleInit {
 
   validateNickname({ nickname }: { nickname: string }) {
     if (!this.authService) {
-      console.log('Auth service is not initialized.');
+      this.logger.error('Auth service is not initialized.');
       return;
     }
     return this.authService.validateNickname({ nickname });

--- a/apps/api-gateway/src/chat/chat.controller.ts
+++ b/apps/api-gateway/src/chat/chat.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Get,
+  Logger,
   Param,
   Post,
   Query,
@@ -17,6 +18,7 @@ import { ChatService } from './chat.service';
 
 @Controller('chat')
 export class ChatController {
+  private readonly logger = new Logger(ChatController.name);
   constructor(private readonly chatService: ChatService) {}
 
   @Get('rooms')
@@ -27,7 +29,7 @@ export class ChatController {
     @Req() req,
   ) {
     const userId = req.user.userId;
-    console.log('Fetching chat rooms for user:', userId);
+    this.logger.debug(`getChatRooms userId=${userId}`);
     return this.chatService.getChatRooms({
       userId,
       page: Number(page) || 1,
@@ -39,8 +41,7 @@ export class ChatController {
   @UseGuards(JwtAuthGuard)
   async createChatRoom(@Body() body: CreateChatRoomRequest, @Req() req) {
     const userId = req.user.userId;
-    console.log('Creating chat room with user:', userId);
-    console.log('Request body:', body);
+    this.logger.log(`createChatRoom userId=${userId}`);
 
     return this.chatService.createChatRoom({
       ...body,
@@ -83,8 +84,7 @@ export class ChatController {
     @Req() req,
   ) {
     const userId = req.user.userId;
-    console.log('Sending message in chat room:', chatRoomId);
-    console.log('Request body:', body);
+    this.logger.debug(`sendMessage room=${chatRoomId} sender=${userId}`);
 
     // 채팅방 ID와 사용자 ID를 포함하여 메시지 전송 요청
     return this.chatService.sendMessage({

--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -3,9 +3,18 @@ import { AppModule } from './app.module';
 import { RpcExceptionFilter } from '@app/common/filters/rpcexception/rpc-exception.filter';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { Logger, LogLevel } from '@nestjs/common';
 import './utils/instrument';
+
+const logLevels: LogLevel[] =
+  process.env.NODE_ENV === 'production'
+    ? ['error', 'warn', 'log']
+    : ['error', 'warn', 'log', 'debug', 'verbose'];
+
 async function bootstrap() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
+    logger: logLevels,
+  });
 
   app.useGlobalFilters(new RpcExceptionFilter());
   /**Swaager설정 */
@@ -27,6 +36,6 @@ async function bootstrap() {
     preflightContinue: false,
   });
   await app.listen(3030);
-  console.log(`Apigateway is running on: ${await app.getUrl()}`);
+  new Logger('Bootstrap').log(`Apigateway is running on: ${await app.getUrl()}`);
 }
 bootstrap();

--- a/apps/api-gateway/src/match/match.controller.ts
+++ b/apps/api-gateway/src/match/match.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  Logger,
   Param,
   Patch,
   Post,
@@ -22,6 +23,7 @@ import { MatchService } from './match.service';
 
 @Controller('match')
 export class MatchController {
+  private readonly logger = new Logger(MatchController.name);
   constructor(private readonly matchService: MatchService) {}
 
   @Get()
@@ -40,9 +42,7 @@ export class MatchController {
   async createMatchPost(@Body() body: CreateMatchPostRequest, @Req() req) {
     const userNumber = req.user.userId;
     const userName = req.user.nickname || 'Unknown';
-    console.log('Creating match post with user:', userName);
-    console.log('Request body:', body);
-    console.log('User number:', userNumber);
+    this.logger.log(`createMatchPost userId=${userNumber} user=${userName}`);
     return this.matchService.createMatchPost({
       ...body,
       userno: userNumber,
@@ -116,12 +116,7 @@ export class MatchController {
     @Req() req,
   ) {
     const userNumber = req.user.userId;
-    console.log('Updating application status:', {
-      matchId,
-      applicationId,
-      status: body.status,
-      userno: userNumber,
-    });
+    this.logger.log(`updateApplicationStatus match=${matchId} app=${applicationId} status=${body.status} userId=${userNumber}`);
     return this.matchService.updateApplicationStatus({
       matchId,
       applicationId,
@@ -153,7 +148,7 @@ export class MatchController {
     @Req() req,
   ) {
     const userNumber = req.user.userId;
-    console.log('Fetching my applications for userno:', userNumber);
+    this.logger.debug(`getMyApplications userId=${userNumber}`);
     return this.matchService.getMyApplications({
       userno: userNumber,
       page: Number(page) || 1,

--- a/apps/api-gateway/src/user/user.controller.ts
+++ b/apps/api-gateway/src/user/user.controller.ts
@@ -5,6 +5,7 @@ import {
   Body,
   Controller,
   Delete,
+  Logger,
   Patch,
   Post,
   Req,
@@ -24,6 +25,7 @@ import { convertToUserEntity } from '@app/common/entity';
 
 @Controller('user')
 export class UserController {
+  private readonly logger = new Logger(UserController.name);
   constructor(private readonly userService: UserService) {}
   @CreateUserSpecDecorator('회원가입 API', '회원가입')
   @Post('/')
@@ -43,8 +45,8 @@ export class UserController {
   @UpdateUserSpecDecorator('회원정보 수정 API', '회원정보 수정')
   @UseGuards(JwtAuthGuard, RateLimitGuard)
   async update(@Req() req, @Body() updateUserDto: UpdateUserDto) {
-    console.log(updateUserDto.nickname);
     const userNumber = req.user.userId;
+    this.logger.log(`updateNickname userId=${userNumber} nickname=${updateUserDto.nickname}`);
     const result = await firstValueFrom(
       this.userService.update({
         ...updateUserDto,
@@ -52,7 +54,6 @@ export class UserController {
       }),
     );
     const user = convertToUserEntity(result);
-    console.log(user);
     return user;
   }
   @Patch('/image')
@@ -81,13 +82,8 @@ export class UserController {
       }),
     );
     const user = convertToUserEntity(result);
-    console.log(user);
+    this.logger.log(`updateProfileImage userId=${userNumber}`);
     return user;
-    //
-    return this.userService.updateProfileImage({
-      ...updateUserDto,
-      id: userNumber,
-    });
   }
 
   @DeleteUserSpecDecorator('회원탈퇴 API', '회원탈퇴')

--- a/apps/article/src/article.service.ts
+++ b/apps/article/src/article.service.ts
@@ -23,6 +23,7 @@ import { MySQLPrismaService } from '@app/prisma';
 import { UtilsService } from '@app/utils';
 import {
   Injectable,
+  Logger,
   NotFoundException,
   ForbiddenException,
 } from '@nestjs/common';
@@ -31,6 +32,7 @@ import { GetArticleRequest } from 'proto/article';
 
 @Injectable()
 export class ArticleService {
+  private readonly logger = new Logger(ArticleService.name);
   constructor(
     private readonly mysqlPrismaService: MySQLPrismaService,
     private readonly utilsService: UtilsService,
@@ -177,7 +179,7 @@ export class ArticleService {
   }
   async deleteArticle(request: DeleteArticleRequest): Promise<void> {
     const { id, userno } = request;
-    console.log('Deleting article with ID:', id, 'for user:', userno);
+    this.logger.log(`deleteArticle id=${id} userId=${userno}`);
 
     // 기존 게시글 조회 및 권한 확인
     const existingArticle = await this.mysqlPrismaService.article.findUnique({

--- a/apps/article/src/main.ts
+++ b/apps/article/src/main.ts
@@ -2,12 +2,19 @@ import { NestFactory } from '@nestjs/core';
 import { ArticleModule } from './article.module';
 import { ARTICLE_PACKAGE_NAME } from '@app/common/protobuf';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { Logger, LogLevel } from '@nestjs/common';
 import { join } from 'path';
+
+const logLevels: LogLevel[] =
+  process.env.NODE_ENV === 'production'
+    ? ['error', 'warn', 'log']
+    : ['error', 'warn', 'log', 'debug', 'verbose'];
 
 async function bootstrap() {
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(
     ArticleModule,
     {
+      logger: logLevels,
       transport: Transport.GRPC,
       options: {
         protoPath: join(__dirname, '../article.proto'),
@@ -18,7 +25,7 @@ async function bootstrap() {
   );
 
   await app.listen();
-  console.log(`Article is running on: 0.0.0.0:${process.env.ARTICLE_GRPC_PORT || '50055'}`);
+  new Logger('Bootstrap').log(`Article is running on: 0.0.0.0:${process.env.ARTICLE_GRPC_PORT || '50055'}`);
 }
 
 bootstrap();

--- a/apps/auth/src/main.ts
+++ b/apps/auth/src/main.ts
@@ -1,12 +1,20 @@
 import { NestFactory } from '@nestjs/core';
 import { AuthModule } from './auth.module';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { Logger, LogLevel } from '@nestjs/common';
 import { join } from 'path';
 import { AUTH_PACKAGE_NAME } from '@app/common/protobuf';
+
+const logLevels: LogLevel[] =
+  process.env.NODE_ENV === 'production'
+    ? ['error', 'warn', 'log']
+    : ['error', 'warn', 'log', 'debug', 'verbose'];
+
 async function bootstrap() {
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(
     AuthModule,
     {
+      logger: logLevels,
       transport: Transport.GRPC,
       options: {
         protoPath: join(__dirname, '../auth.proto'),
@@ -16,7 +24,7 @@ async function bootstrap() {
     },
   );
   await app.listen();
-  console.log(`Auth is running on: 0.0.0.0:${process.env.AUTH_GRPC_PORT || '50051'}`);
+  new Logger('Bootstrap').log(`Auth is running on: 0.0.0.0:${process.env.AUTH_GRPC_PORT || '50051'}`);
 }
 
 bootstrap();

--- a/apps/chat/src/chat.gateway.ts
+++ b/apps/chat/src/chat.gateway.ts
@@ -8,6 +8,7 @@ import {
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
+import { Logger } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import { onlineMap } from './online.map';
 import { MySQLPrismaService } from '@app/prisma';
@@ -16,12 +17,13 @@ import { MySQLPrismaService } from '@app/prisma';
 export class ChatGateway
   implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
 {
+  private readonly logger = new Logger(ChatGateway.name);
   constructor(private readonly prisma: MySQLPrismaService) {}
   @WebSocketServer() public server: Server;
 
   @SubscribeMessage('health')
   handleHealth(@ConnectedSocket() socket: Socket) {
-    console.log('health', socket.nsp.name);
+    this.logger.verbose(`health ${socket.nsp.name}`);
     return 'pong';
   }
 
@@ -36,7 +38,7 @@ export class ChatGateway
     },
     @ConnectedSocket() socket: Socket,
   ) {
-    console.log('handleSendMessage', data, socket.nsp.name);
+    this.logger.debug(`handleSendMessage ns=${socket.nsp.name} room=${data.chatRoomId}`);
     try {
       // 새로운 Chat 시스템을 사용하여 메시지 저장
       const message = await this.prisma.chatMessage.create({
@@ -73,7 +75,7 @@ export class ChatGateway
     @MessageBody() data: { userId: number; chatRoomId: string },
     @ConnectedSocket() socket: Socket,
   ) {
-    console.log('handleJoinRoom', data, socket.nsp.name);
+    this.logger.debug(`handleJoinRoom userId=${data.userId} room=${data.chatRoomId} ns=${socket.nsp.name}`);
 
     // 온라인 맵에 사용자 추가
     if (!onlineMap[socket.nsp.name]) {
@@ -84,19 +86,18 @@ export class ChatGateway
     // 채팅방에 참여
     const roomName = `${socket.nsp.name}-${data.chatRoomId}`;
     socket.join(roomName);
-    console.log(`User ${data.userId} joined room ${roomName}`);
+    this.logger.log(`User ${data.userId} joined room ${roomName}`);
 
     // 온라인 사용자 목록 업데이트
     socket.nsp.emit('onlineList', Object.values(onlineMap[socket.nsp.name]));
   }
 
   afterInit(_server: Server): any {
-    console.log(_server);
-    console.log('init');
+    this.logger.log('ChatGateway initialized');
   }
 
   handleConnection(@ConnectedSocket() socket: Socket) {
-    console.log('connected', socket.nsp.name);
+    this.logger.verbose(`connected ${socket.nsp.name}`);
     if (!onlineMap[socket.nsp.name]) {
       onlineMap[socket.nsp.name] = {};
     }
@@ -104,7 +105,7 @@ export class ChatGateway
   }
 
   handleDisconnect(@ConnectedSocket() socket: Socket) {
-    console.log('disconnected', socket.nsp.name);
+    this.logger.verbose(`disconnected ${socket.nsp.name}`);
     const newNamespace = socket.nsp;
     if (onlineMap[socket.nsp.name]) {
       delete onlineMap[socket.nsp.name][socket.id];

--- a/apps/chat/src/chat.service.ts
+++ b/apps/chat/src/chat.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  Logger,
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
@@ -21,6 +22,7 @@ import {
 
 @Injectable()
 export class ChatService {
+  private readonly logger = new Logger(ChatService.name);
   constructor(private readonly prisma: MySQLPrismaService) {}
 
   // 새로운 1:1 채팅방 생성
@@ -28,7 +30,7 @@ export class ChatService {
     request: CreateChatRoomRequest,
   ): Promise<CreateChatRoomResponse> {
     const { memberIds, roomName, type = 'direct' } = request;
-    console.log(request);
+    this.logger.log(`createChatRoom type=${type} members=${memberIds.join(',')}`);
 
     // direct 타입인 경우 2명만 허용
     if (type === 'direct' && memberIds.length !== 2) {
@@ -195,7 +197,7 @@ export class ChatService {
   // 메시지 전송
   async sendMessage(request: SendMessageRequest): Promise<SendMessageResponse> {
     const { chatRoomId, senderId, content } = request;
-    console.log('Sending message:', request);
+    this.logger.debug(`sendMessage room=${chatRoomId} sender=${senderId}`);
 
     // 채팅방 멤버인지 확인
     const membership = await this.prisma.chatRoomMember.findFirst({

--- a/apps/chat/src/main.ts
+++ b/apps/chat/src/main.ts
@@ -3,13 +3,19 @@ import { IoAdapter } from '@nestjs/platform-socket.io';
 import { ChatModule } from './chat.module';
 import { CHAT_PACKAGE_NAME } from '@app/common/protobuf';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { Logger, LogLevel } from '@nestjs/common';
 import { join } from 'path';
 
+const logLevels: LogLevel[] =
+  process.env.NODE_ENV === 'production'
+    ? ['error', 'warn', 'log']
+    : ['error', 'warn', 'log', 'debug', 'verbose'];
+
 async function bootstrap() {
-  // gRPC 마이크로서비스 생성
   const grpcApp = await NestFactory.createMicroservice<MicroserviceOptions>(
     ChatModule,
     {
+      logger: logLevels,
       transport: Transport.GRPC,
       options: {
         protoPath: join(__dirname, '../chat.proto'),
@@ -19,16 +25,15 @@ async function bootstrap() {
     },
   );
 
-  // WebSocket 서버도 유지 (기존 기능)
-  const httpApp = await NestFactory.create(ChatModule);
+  const httpApp = await NestFactory.create(ChatModule, { logger: logLevels });
   httpApp.useWebSocketAdapter(new IoAdapter(httpApp));
 
-  // 두 서버 모두 시작
   await grpcApp.listen();
   await httpApp.listen(Number(process.env.CHAT_WS_PORT) || 3031);
 
-  console.log(`Chat gRPC service is running on: 0.0.0.0:${process.env.CHAT_GRPC_PORT || '50057'}`);
-  console.log(`Chat WebSocket service is running on: http://localhost:${process.env.CHAT_WS_PORT || '3031'}`);
+  const logger = new Logger('Bootstrap');
+  logger.log(`Chat gRPC service is running on: 0.0.0.0:${process.env.CHAT_GRPC_PORT || '50057'}`);
+  logger.log(`Chat WebSocket service is running on: http://localhost:${process.env.CHAT_WS_PORT || '3031'}`);
 }
 
 bootstrap();

--- a/apps/cron/src/main.ts
+++ b/apps/cron/src/main.ts
@@ -1,10 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { CronModule } from './cron.module';
+import { Logger, LogLevel } from '@nestjs/common';
+
+const logLevels: LogLevel[] =
+  process.env.NODE_ENV === 'production'
+    ? ['error', 'warn', 'log']
+    : ['error', 'warn', 'log', 'debug', 'verbose'];
 
 async function bootstrap() {
-  const app = await NestFactory.create(CronModule);
+  const app = await NestFactory.create(CronModule, { logger: logLevels });
   await app.listen(3001);
-  console.log(`Cron is running on:0.0.0.0:3001`);
+  new Logger('Bootstrap').log('Cron is running on: 0.0.0.0:3001');
 }
 
 bootstrap();

--- a/apps/cron/src/movie/movie.service.ts
+++ b/apps/cron/src/movie/movie.service.ts
@@ -3,12 +3,13 @@ import {
   MOVIE_SERVICE_NAME,
   MovieServiceClient,
 } from '@app/common/protobuf';
-import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ClientGrpc } from '@nestjs/microservices';
 import moment from 'moment';
 import { firstValueFrom } from 'rxjs';
 @Injectable()
 export class MovieService implements OnModuleInit {
+  private readonly logger = new Logger(MovieService.name);
   private movieService: MovieServiceClient;
   constructor(
     @Inject(MOVIE_PACKAGE_NAME)
@@ -31,7 +32,7 @@ export class MovieService implements OnModuleInit {
       const result = await firstValueFrom(observableData);
       return result;
     } catch (error) {
-      console.log(error);
+      this.logger.error('fetchMoviedata failed', error);
     }
   }
 }

--- a/apps/match/src/main.ts
+++ b/apps/match/src/main.ts
@@ -1,13 +1,20 @@
 import { NestFactory } from '@nestjs/core';
 import { MATCH_PACKAGE_NAME } from '@app/common/protobuf';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { Logger, LogLevel } from '@nestjs/common';
 import { join } from 'path';
 import { MatchModule } from './match.module';
+
+const logLevels: LogLevel[] =
+  process.env.NODE_ENV === 'production'
+    ? ['error', 'warn', 'log']
+    : ['error', 'warn', 'log', 'debug', 'verbose'];
 
 async function bootstrap() {
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(
     MatchModule,
     {
+      logger: logLevels,
       transport: Transport.GRPC,
       options: {
         protoPath: join(__dirname, '../match.proto'),
@@ -18,7 +25,7 @@ async function bootstrap() {
   );
 
   await app.listen();
-  console.log(`Match is running on: 0.0.0.0:${process.env.MATCH_GRPC_PORT || '50059'}`);
+  new Logger('Bootstrap').log(`Match is running on: 0.0.0.0:${process.env.MATCH_GRPC_PORT || '50059'}`);
 }
 
 bootstrap();

--- a/apps/match/src/match.service.ts
+++ b/apps/match/src/match.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  Logger,
   NotFoundException,
   ForbiddenException,
   BadRequestException,
@@ -32,6 +33,7 @@ import {
 
 @Injectable()
 export class MatchService {
+  private readonly logger = new Logger(MatchService.name);
   private chatService: ChatService;
 
   constructor(
@@ -187,7 +189,6 @@ export class MatchService {
         },
       },
     });
-    console.log(matchPost);
     if (!matchPost) {
       return {
         matchPost: null,
@@ -334,7 +335,7 @@ export class MatchService {
 
   async applyToMatch(request: ApplyToMatchRequest): Promise<CommonResponse> {
     const { matchId, applicantUserno, applicantName, message } = request;
-    console.log(matchId, applicantUserno, applicantName, message);
+    this.logger.log(`applyToMatch matchId=${matchId} applicant=${applicantUserno}`);
 
     // 게시글 존재 여부 확인
     const matchPost = await this.mysqlPrismaService.matchPost.findFirst({
@@ -404,12 +405,7 @@ export class MatchService {
     request: GetMatchApplicationsRequest,
   ): Promise<MatchApplicationsResponse> {
     const { matchId, userno } = request;
-    console.log(
-      'Fetching applications for matchId:',
-      matchId,
-      'by userno:',
-      userno,
-    );
+    this.logger.debug(`getMatchApplications matchId=${matchId} requestedBy=${userno}`);
 
     // 게시글 존재 여부 확인
     const matchPost = await this.mysqlPrismaService.matchPost.findFirst({
@@ -430,7 +426,6 @@ export class MatchService {
       };
     }
 
-    console.log(matchId);
     const applications =
       await this.mysqlPrismaService.matchApplication.findMany({
         where: {
@@ -440,7 +435,7 @@ export class MatchService {
           createdAt: 'desc',
         },
       });
-    console.log('Applications found:', applications.length);
+    this.logger.debug(`getMatchApplications matchId=${matchId} count=${applications.length}`);
     const formattedApplications: MatchApplication[] = await Promise.all(
       applications.map(async (app) => {
         // 지원자 User 정보 조회
@@ -469,7 +464,7 @@ export class MatchService {
     request: UpdateApplicationStatusRequest,
   ): Promise<ApplicationResponse> {
     const { matchId, applicationId, status, userno } = request;
-    console.log(matchId, applicationId, status, userno);
+    this.logger.log(`updateApplicationStatus match=${matchId} app=${applicationId} status=${status} userId=${userno}`);
 
     // 게시글 존재 여부 및 권한 확인
     const matchPost = await this.mysqlPrismaService.matchPost.findFirst({
@@ -637,7 +632,7 @@ export class MatchService {
   ): Promise<MatchApplicationsResponse> {
     const { userno, page = 1, pageSize = 10 } = request;
     const skip = (page - 1) * pageSize;
-    console.log('Fetching applications for userno:', userno);
+    this.logger.debug(`getMyApplications userId=${userno}`);
 
     const applications =
       await this.mysqlPrismaService.matchApplication.findMany({

--- a/apps/movie/src/main.ts
+++ b/apps/movie/src/main.ts
@@ -1,13 +1,20 @@
 import { NestFactory } from '@nestjs/core';
 import { MovieModule } from './movie.module';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { Logger, LogLevel } from '@nestjs/common';
 import { join } from 'path';
 import { MOVIE_PACKAGE_NAME } from '@app/common/protobuf';
+
+const logLevels: LogLevel[] =
+  process.env.NODE_ENV === 'production'
+    ? ['error', 'warn', 'log']
+    : ['error', 'warn', 'log', 'debug', 'verbose'];
 
 async function bootstrap() {
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(
     MovieModule,
     {
+      logger: logLevels,
       transport: Transport.GRPC,
       options: {
         protoPath: join(__dirname, '../movie.proto'),
@@ -17,6 +24,6 @@ async function bootstrap() {
     },
   );
   await app.listen();
-  console.log(`Movie is running on: 0.0.0.0:${process.env.MOVIE_GRPC_PORT || '50054'}`);
+  new Logger('Bootstrap').log(`Movie is running on: 0.0.0.0:${process.env.MOVIE_GRPC_PORT || '50054'}`);
 }
 bootstrap();

--- a/apps/reply/src/main.ts
+++ b/apps/reply/src/main.ts
@@ -1,12 +1,20 @@
 import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { Logger, LogLevel } from '@nestjs/common';
 import { join } from 'path';
 import { REPLY_PACKAGE_NAME } from '@app/common/protobuf';
 import { ReplyModule } from './reply.module';
+
+const logLevels: LogLevel[] =
+  process.env.NODE_ENV === 'production'
+    ? ['error', 'warn', 'log']
+    : ['error', 'warn', 'log', 'debug', 'verbose'];
+
 async function bootstrap() {
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(
     ReplyModule,
     {
+      logger: logLevels,
       transport: Transport.GRPC,
       options: {
         protoPath: join(__dirname, '../reply.proto'),
@@ -16,7 +24,7 @@ async function bootstrap() {
     },
   );
   await app.listen();
-  console.log(`Reply is running on: 0.0.0.0:${process.env.REPLY_GRPC_PORT || '50053'}`);
+  new Logger('Bootstrap').log(`Reply is running on: 0.0.0.0:${process.env.REPLY_GRPC_PORT || '50053'}`);
 }
 
 bootstrap();

--- a/apps/reply/src/reply.service.ts
+++ b/apps/reply/src/reply.service.ts
@@ -7,10 +7,11 @@ import {
 import { NotFoundException } from '@app/common/filters/rpcexception/rpc-exception';
 import { MySQLPrismaService } from '@app/prisma';
 import { UtilsService } from '@app/utils';
-import { Injectable, ForbiddenException } from '@nestjs/common';
+import { Injectable, Logger, ForbiddenException } from '@nestjs/common';
 
 @Injectable()
 export class ReplyService {
+  private readonly logger = new Logger(ReplyService.name);
   constructor(
     private readonly mysqlPrismaService: MySQLPrismaService,
     private readonly utilsService: UtilsService,
@@ -154,7 +155,7 @@ export class ReplyService {
         where: { movieId, deletedAt: null },
       }),
     ]);
-    console.log('Replies:', replies);
+    this.logger.debug(`getReplies movieId=${movieId} count=${replies.length}`);
     const replyObjects: Reply[] = replies.map((reply) => ({
       replyId: reply.id,
       comment: reply.comment,

--- a/apps/user/src/main.ts
+++ b/apps/user/src/main.ts
@@ -1,12 +1,20 @@
 import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { Logger, LogLevel } from '@nestjs/common';
 import { join } from 'path';
 import { USER_PACKAGE_NAME } from '@app/common/protobuf';
 import { UserModule } from './user.module';
+
+const logLevels: LogLevel[] =
+  process.env.NODE_ENV === 'production'
+    ? ['error', 'warn', 'log']
+    : ['error', 'warn', 'log', 'debug', 'verbose'];
+
 async function bootstrap() {
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(
     UserModule,
     {
+      logger: logLevels,
       transport: Transport.GRPC,
       options: {
         protoPath: join(__dirname, '../user.proto'),
@@ -16,6 +24,6 @@ async function bootstrap() {
     },
   );
   await app.listen();
-  console.log(`User is running on: 0.0.0.0:${process.env.USER_GRPC_PORT || '50052'}`);
+  new Logger('Bootstrap').log(`User is running on: 0.0.0.0:${process.env.USER_GRPC_PORT || '50052'}`);
 }
 bootstrap();

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -7,10 +7,11 @@ import {
 import { AlreadyExistsException } from '@app/common/filters/rpcexception/rpc-exception';
 import { MySQLPrismaService } from '@app/prisma';
 import { UtilsService } from '@app/utils';
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { hash } from 'bcryptjs';
 @Injectable()
 export class UserService {
+  private readonly logger = new Logger(UserService.name);
   constructor(
     private readonly mysqlPrismaService: MySQLPrismaService,
     private readonly utilsService: UtilsService,
@@ -19,7 +20,7 @@ export class UserService {
   async create(createUserDto: CreateUserDto): Promise<User> {
     const { email, password, nickname, marketingAgreed, gender } =
       createUserDto;
-    console.log('createUserDto', createUserDto);
+    this.logger.log(`createUser email=${createUserDto.email}`);
     const hashedPassword = await hash(password, 10);
     const existedNickname = await this.mysqlPrismaService.user.findFirst({
       where: { nickname },
@@ -154,7 +155,7 @@ export class UserService {
     if (!userData) {
       throw new NotFoundException(`User not found ${id}`);
     }
-    console.log('updateUserProfileImage', image);
+    this.logger.log(`updateUserProfileImage userId=${id}`);
     const updatedUserData = await this.mysqlPrismaService.user.update({
       where: { id },
       data: { image: image },


### PR DESCRIPTION
## Summary
- 백엔드 전체 `console.log` 52개 → NestJS `Logger` 전환
- `main.ts` 9개에 `NODE_ENV` 기반 로그 레벨 제어 추가

## 레벨 분류 기준
| 레벨 | 적용 예시 |
|------|---------|
| `error` | gRPC 서비스 미초기화, cron 에러 |
| `log` | 채팅방 생성, 매치 신청/상태 변경, 유저 수정 |
| `debug` | 요청 파라미터 덤프, 조회 카운트 |
| `verbose` | 소켓 connect/disconnect, health 체크 |

## 로그 레벨 제어
```
# .env.production
NODE_ENV=production   → error, warn, log만 출력
# 개발 환경         → 모든 레벨 출력
```

## Test plan
- [ ] 서버 재배포 후 `docker logs` 에서 NestJS 포맷([서비스명]) 확인
- [ ] 프로덕션에서 debug/verbose 로그 미출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)