### PR TITLE
🐛 프로필 이미지 URL 이중 슬래시 및 빈 이미지 처리 수정

### DIFF
--- a/libs/common/src/entity/users-entity.ts
+++ b/libs/common/src/entity/users-entity.ts
@@ -5,7 +5,9 @@ export function convertToUserEntity(arg: any) {
     id: arg.id,
     email: arg.email,
     nickname: arg.nickname,
-    image: process.env.FILE_SERVER_API + arg.image,
+    image: arg.image
+      ? (process.env.FILE_SERVER_API ?? '').replace(/\/$/, '') + arg.image
+      : '',
     createdAt: arg.createdAt,
     updatedAt: arg.updatedAt,
     deletedAt: arg.deletedAt ?? null,


### PR DESCRIPTION
## Summary
- `FILE_SERVER_API`(trailing slash) + `/uploads/...`(leading slash) 조합으로 이중 슬래시 발생하던 문제 수정
- `arg.image`가 빈 문자열일 때 `FILE_SERVER_API`만 반환하던 문제 수정 (빈 문자열 반환)

## 원인
\`convertToUserEntity\`에서 단순 문자열 연결로 URL을 조합하여
- trailing slash + leading slash → 이중 슬래시
- 빈 이미지 경우 → `https://domain/` 같은 잘못된 URL 반환

## 변경
- `libs/common/src/entity/users-entity.ts`: `arg.image` truthy 체크 추가, `FILE_SERVER_API` trailing slash 제거 후 연결

## Test plan
- [ ] 서버 `.env.production`의 `FILE_SERVER_API=http://58.79.17.11` 으로 업데이트 후 `docker compose up -d --force-recreate api-gateway`
- [ ] 커스텀 이미지 업로드 후 URL이 `http://58.79.17.11/uploads/...` 형태인지 확인
- [ ] 이미지 없는 유저의 이미지 필드가 빈 문자열인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)