### PR TITLE
🐛 ServeStaticModule 중복 제거 — useStaticAssets 단일 사용

### DIFF
--- a/apps/api-gateway/src/app.module.ts
+++ b/apps/api-gateway/src/app.module.ts
@@ -6,18 +6,12 @@ import { MovieModule } from './movie/movie.module';
 import { ReplyModule } from './reply/reply.module';
 import { UserModule } from './user/user.module';
 import { SentryModule } from '@sentry/nestjs/setup';
-import { ServeStaticModule } from '@nestjs/serve-static';
-import { join } from 'path';
 import { ArticleModule } from './article/article.module';
 import { MatchModule } from './match/match.module';
 import { ChatModule } from './chat/chat.module';
 
 @Module({
   imports: [
-    ServeStaticModule.forRoot({
-      rootPath: join(__dirname, '../../../../uploads'),
-      serveRoot: '/uploads',
-    }),
     ConfigModule.forRoot({
       envFilePath:
         process.env.NODE_ENV === 'production'


### PR DESCRIPTION
## Summary
프로필 이미지 `/uploads/` 경로 502 원인 수정

## 원인
`app.module.ts`의 `ServeStaticModule`과 `main.ts`의 `useStaticAssets`가 모두 `/uploads/` 경로를 처리하도록 설정되어 충돌 발생. nginx가 api-gateway에서 응답을 받지 못해 502 반환.

## 변경
- `app.module.ts`: `ServeStaticModule.forRoot(...)` 제거
- 정적 파일 서빙은 `main.ts`의 `app.useStaticAssets(join(process.cwd(), 'uploads'), { prefix: '/uploads/' })` 단일 설정으로 통일

## Test plan
- [ ] 프로필 이미지 업로드 후 `/uploads/filename.png` 정상 서빙 확인
- [ ] 배포 후 `docker exec api-gateway ls /usr/src/app/uploads/` 파일 존재 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)