### PR TITLE
🐛 매치 라우트 순서 수정 — my-posts/my-applications을 :matchId 앞으로

### DIFF
--- a/apps/api-gateway/src/match/match.controller.ts
+++ b/apps/api-gateway/src/match/match.controller.ts
@@ -50,6 +50,38 @@ export class MatchController {
     });
   }
 
+  // 특정 라우트는 :matchId 파라미터 라우트보다 반드시 먼저 선언해야 함
+  @Get('my-posts')
+  @UseGuards(JwtAuthGuard)
+  async getMyPosts(
+    @Query('page') page: string,
+    @Query('pageSize') pageSize: string,
+    @Req() req,
+  ) {
+    const userNumber = req.user.userId;
+    return this.matchService.getMyPosts({
+      userno: userNumber,
+      page: Number(page) || 1,
+      pageSize: Number(pageSize) || 10,
+    });
+  }
+
+  @Get('my-applications')
+  @UseGuards(JwtAuthGuard)
+  async getMyApplications(
+    @Query('page') page: string,
+    @Query('pageSize') pageSize: string,
+    @Req() req,
+  ) {
+    const userNumber = req.user.userId;
+    this.logger.debug(`getMyApplications userId=${userNumber}`);
+    return this.matchService.getMyApplications({
+      userno: userNumber,
+      page: Number(page) || 1,
+      pageSize: Number(pageSize) || 10,
+    });
+  }
+
   @Get(':matchId')
   async getMatchPost(@Param('matchId') matchId: string) {
     return this.matchService.getMatchPost({ matchId });
@@ -122,37 +154,6 @@ export class MatchController {
       applicationId,
       status: body.status,
       userno: userNumber,
-    });
-  }
-
-  @Get('my-posts')
-  @UseGuards(JwtAuthGuard)
-  async getMyPosts(
-    @Query('page') page: string,
-    @Query('pageSize') pageSize: string,
-    @Req() req,
-  ) {
-    const userNumber = req.user.userId;
-    return this.matchService.getMyPosts({
-      userno: userNumber,
-      page: Number(page) || 1,
-      pageSize: Number(pageSize) || 10,
-    });
-  }
-
-  @Get('my-applications')
-  @UseGuards(JwtAuthGuard)
-  async getMyApplications(
-    @Query('page') page: string,
-    @Query('pageSize') pageSize: string,
-    @Req() req,
-  ) {
-    const userNumber = req.user.userId;
-    this.logger.debug(`getMyApplications userId=${userNumber}`);
-    return this.matchService.getMyApplications({
-      userno: userNumber,
-      page: Number(page) || 1,
-      pageSize: Number(pageSize) || 10,
     });
   }
 


### PR DESCRIPTION
## Summary
내 매칭 목록이 표시되지 않는 문제 수정

## 원인
Express 어댑터는 선언 순서대로 라우트를 처리함.
`@Get(':matchId')`가 `@Get('my-posts')`, `@Get('my-applications')` 보다 먼저 등록되어
`GET /match/my-posts` 요청이 `matchId='my-posts'`로 처리되고 실제 핸들러에 도달하지 못함.

## 변경
- `match.controller.ts`: `my-posts`, `my-applications` 라우트를 `:matchId` 파라미터 라우트 앞으로 이동

## Test plan
- [ ] `/match/my-posts` → 내가 만든 매칭 목록 정상 반환 확인
- [ ] `/match/my-applications` → 내가 신청한 매칭 목록 정상 반환 확인
- [ ] 기존 `/match/:matchId` 상세 조회 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)