### PR TITLE
✨ DB 기반 알림 시스템 추가

### DIFF
--- a/apps/api-gateway/src/app.module.ts
+++ b/apps/api-gateway/src/app.module.ts
@@ -9,6 +9,7 @@ import { SentryModule } from '@sentry/nestjs/setup';
 import { ArticleModule } from './article/article.module';
 import { MatchModule } from './match/match.module';
 import { ChatModule } from './chat/chat.module';
+import { NotificationModule } from './notification/notification.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { ChatModule } from './chat/chat.module';
     ArticleModule,
     MatchModule,
     ChatModule,
+    NotificationModule,
   ],
   controllers: [],
   providers: [JwtStrategy],

--- a/apps/api-gateway/src/notification/notification.controller.ts
+++ b/apps/api-gateway/src/notification/notification.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Patch, Param, Query, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '@app/common/guards/jwtauth/jwtauth.guard';
+import { NotificationService } from './notification.service';
+
+@Controller('notifications')
+@UseGuards(JwtAuthGuard)
+export class NotificationController {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  @Get()
+  getNotifications(
+    @Req() req,
+    @Query('page') page: string,
+    @Query('pageSize') pageSize: string,
+  ) {
+    return this.notificationService.getNotifications(
+      req.user.userId,
+      Number(page) || 1,
+      Number(pageSize) || 20,
+    );
+  }
+
+  @Get('unread-count')
+  getUnreadCount(@Req() req) {
+    return this.notificationService.getUnreadCount(req.user.userId);
+  }
+
+  @Patch('read-all')
+  markAllAsRead(@Req() req) {
+    return this.notificationService.markAllAsRead(req.user.userId);
+  }
+
+  @Patch(':id/read')
+  markAsRead(@Req() req, @Param('id') id: string) {
+    return this.notificationService.markAsRead(req.user.userId, id);
+  }
+}

--- a/apps/api-gateway/src/notification/notification.module.ts
+++ b/apps/api-gateway/src/notification/notification.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@app/prisma';
+import { NotificationService } from './notification.service';
+import { NotificationController } from './notification.controller';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [NotificationController],
+  providers: [NotificationService],
+})
+export class NotificationModule {}

--- a/apps/api-gateway/src/notification/notification.service.ts
+++ b/apps/api-gateway/src/notification/notification.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { MySQLPrismaService } from '@app/prisma';
+
+@Injectable()
+export class NotificationService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async getNotifications(userId: number, page = 1, pageSize = 20) {
+    const skip = (page - 1) * pageSize;
+    const [items, total] = await Promise.all([
+      this.prisma.notification.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: pageSize,
+      }),
+      this.prisma.notification.count({ where: { userId } }),
+    ]);
+    return { items, total, hasNext: skip + pageSize < total };
+  }
+
+  async getUnreadCount(userId: number) {
+    const count = await this.prisma.notification.count({
+      where: { userId, isRead: false },
+    });
+    return { count };
+  }
+
+  async markAsRead(userId: number, id: string) {
+    await this.prisma.notification.updateMany({
+      where: { id, userId },
+      data: { isRead: true },
+    });
+    return { success: true };
+  }
+
+  async markAllAsRead(userId: number) {
+    await this.prisma.notification.updateMany({
+      where: { userId, isRead: false },
+      data: { isRead: true },
+    });
+    return { success: true };
+  }
+}

--- a/apps/chat/src/chat.service.ts
+++ b/apps/chat/src/chat.service.ts
@@ -227,6 +227,31 @@ export class ChatService {
       data: { updatedAt: new Date() },
     });
 
+    // 발신자 제외 다른 멤버에게 알림 생성
+    const [otherMembers, sender] = await Promise.all([
+      this.prisma.chatRoomMember.findMany({
+        where: { chatRoomId, userId: { not: senderId }, leftAt: null },
+      }),
+      this.prisma.user.findUnique({
+        where: { id: senderId },
+        select: { nickname: true },
+      }),
+    ]);
+    const preview = content.length > 40 ? content.slice(0, 40) + '…' : content;
+    await Promise.all(
+      otherMembers.map((m) =>
+        this.prisma.notification.create({
+          data: {
+            userId: m.userId,
+            type: 'chat_message',
+            title: sender?.nickname || '알 수 없음',
+            body: preview,
+            targetId: chatRoomId,
+          },
+        }).catch(() => {}),
+      ),
+    );
+
     return {
       message: {
         id: message.id,

--- a/apps/match/src/match.service.ts
+++ b/apps/match/src/match.service.ts
@@ -395,6 +395,16 @@ export class MatchService {
       },
     });
 
+    await this.mysqlPrismaService.notification.create({
+      data: {
+        userId: matchPost.userno,
+        type: 'match_apply',
+        title: '새로운 매칭 신청',
+        body: `${applicantName}님이 "${matchPost.title}"에 신청했습니다.`,
+        targetId: matchId,
+      },
+    }).catch(() => {});
+
     return {
       success: true,
       message: 'Application submitted successfully',

--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -69,6 +69,7 @@ model User {
   MatchApplication MatchApplication[]
   ChatRoomMember   ChatRoomMember[]
   ChatMessage      ChatMessage[]
+  Notification     Notification[]
 }
 
 
@@ -251,4 +252,19 @@ enum ChatRoom_type {
 enum User_gender {
   male
   female
+}
+
+model Notification {
+  id        String   @id @default(cuid())
+  userId    Int
+  type      String   @db.VarChar(50)
+  title     String   @db.VarChar(255)
+  body      String   @db.VarChar(500)
+  isRead    Boolean  @default(false)
+  targetId  String?  @db.VarChar(255)
+  createdAt DateTime @default(now()) @db.DateTime(6)
+  User      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, isRead])
+  @@map("notifications")
 }


### PR DESCRIPTION
## Summary
매칭 신청 및 채팅 메시지 수신 시 DB에 알림을 쌓는 기능 추가

## 변경
- `prisma/mysql.schema.prisma`: Notification 모델 추가
- `apps/match`: applyToMatch 시 매치 작성자에게 알림 생성
- `apps/chat`: sendMessage 시 발신자 제외 멤버에게 알림 생성
- `apps/api-gateway/notification/`: NotificationModule 신규
  - `GET /notifications` — 내 알림 목록
  - `GET /notifications/unread-count` — 미읽음 수
  - `PATCH /notifications/read-all` — 전체 읽음 처리
  - `PATCH /notifications/:id/read` — 단건 읽음 처리

## Deploy 전 필요 작업
서버에서 Prisma 마이그레이션 실행:
\`\`\`bash
docker compose run --rm api-gateway sh -c "prisma migrate dev --name add-notification --schema prisma/mysql.schema.prisma"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)