### PR TITLE
⚡️ N+1 쿼리 제거 — match/movie 서비스

### DIFF
--- a/apps/match/src/match.service.ts
+++ b/apps/match/src/match.service.ts
@@ -441,29 +441,24 @@ export class MatchService {
         where: {
           matchPostId: matchId,
         },
+        include: {
+          User: { select: { gender: true } },
+        },
         orderBy: {
           createdAt: 'desc',
         },
       });
     this.logger.debug(`getMatchApplications matchId=${matchId} count=${applications.length}`);
-    const formattedApplications: MatchApplication[] = await Promise.all(
-      applications.map(async (app) => {
-        // 지원자 User 정보 조회
-        const user = await this.mysqlPrismaService.user.findUnique({
-          where: { id: app.applicantUserno },
-        });
-        return {
-          id: app.id,
-          matchPostId: app.matchPostId,
-          applicantUserno: app.applicantUserno,
-          applicantName: app.applicantName,
-          message: app.message,
-          status: app.status,
-          createdAt: app.createdAt.toISOString(),
-          gender: user?.gender || '',
-        };
-      }),
-    );
+    const formattedApplications: MatchApplication[] = applications.map((app) => ({
+      id: app.id,
+      matchPostId: app.matchPostId,
+      applicantUserno: app.applicantUserno,
+      applicantName: app.applicantName,
+      message: app.message,
+      status: app.status,
+      createdAt: app.createdAt.toISOString(),
+      gender: app.User?.gender || '',
+    }));
 
     return {
       applications: formattedApplications,
@@ -655,6 +650,7 @@ export class MatchService {
               User: true,
             },
           },
+          User: { select: { gender: true } },
         },
         orderBy: {
           createdAt: 'desc',
@@ -663,24 +659,16 @@ export class MatchService {
         take: pageSize,
       });
 
-    const formattedApplications: MatchApplication[] = await Promise.all(
-      applications.map(async (app) => {
-        // 지원자 User 정보 조회
-        const user = await this.mysqlPrismaService.user.findUnique({
-          where: { id: app.applicantUserno },
-        });
-        return {
-          id: app.id,
-          matchPostId: app.matchPostId,
-          applicantUserno: app.applicantUserno,
-          applicantName: app.applicantName,
-          message: app.message,
-          status: app.status,
-          createdAt: app.createdAt.toISOString(),
-          gender: user?.gender || '',
-        };
-      }),
-    );
+    const formattedApplications: MatchApplication[] = applications.map((app) => ({
+      id: app.id,
+      matchPostId: app.matchPostId,
+      applicantUserno: app.applicantUserno,
+      applicantName: app.applicantName,
+      message: app.message,
+      status: app.status,
+      createdAt: app.createdAt.toISOString(),
+      gender: app.User?.gender || '',
+    }));
 
     return {
       applications: formattedApplications,

--- a/apps/movie/src/movie.service.ts
+++ b/apps/movie/src/movie.service.ts
@@ -263,7 +263,12 @@ export class MovieService implements OnModuleInit {
       },
       include: {
         MovieVod: true,
-        movieScores: true, // Include movieScores for average calculation
+        movieScores: true,
+        _count: {
+          select: {
+            Comment: { where: { deletedAt: null } },
+          },
+        },
       },
       take: 10,
       orderBy: [
@@ -273,23 +278,11 @@ export class MovieService implements OnModuleInit {
       ],
     });
 
-    // soft delete되지 않은 댓글 개수 병렬 조회
-    const commentCounts = await Promise.all(
-      movieList.map((movie) =>
-        this.mysqlPrismaService.comment.count({
-          where: {
-            movieId: movie.movieCd,
-            deletedAt: null,
-          },
-        }),
-      ),
-    );
-
-    const convertedMovieList = movieList.map((movieData, idx) =>
+    const convertedMovieList = movieList.map((movieData) =>
       this.convertMovieDataWithCounts({
         ...movieData,
         _count: {
-          Comment: commentCounts[idx],
+          Comment: movieData._count.Comment,
           movieScores: movieData.movieScores?.length ?? 0,
         },
       }),
@@ -417,24 +410,21 @@ export class MovieService implements OnModuleInit {
       include: {
         MovieVod: true,
         movieScores: true,
+        _count: {
+          select: {
+            Comment: { where: { deletedAt: null } },
+          },
+        },
       },
     });
     if (!movie) {
       throw new Error(`Movie with movieCd ${movieCd} not found`);
     }
 
-    // soft delete되지 않은 댓글 개수 구하기
-    const commentCount = await this.mysqlPrismaService.comment.count({
-      where: {
-        movieId: movie.movieCd,
-        deletedAt: null,
-      },
-    });
-    // convertMovieDataWithCounts에 commentCount를 전달하도록 수정
     return this.convertMovieDataWithCounts({
       ...movie,
       _count: {
-        Comment: commentCount,
+        Comment: movie._count.Comment,
         movieScores: movie.movieScores?.length ?? 0,
       },
     });


### PR DESCRIPTION
## Summary
백엔드 N+1 쿼리 4건을 \`include\` / \`_count\`로 단일 쿼리화

## 변경

### match.service.ts
- \`getMatchApplications\`: 매치 신청 N건 → 신청자별 \`user.findUnique\` N+1
  - Fix: \`include: { User: { select: { gender: true } } }\` 로 1쿼리
- \`getMyApplications\`: 동일 패턴 (gender만 조회) → 동일 fix

### movie.service.ts
- \`getMovieDatas\`: 영화 10건 → 영화별 \`comment.count\` 10+1쿼리
  - Fix: \`_count: { select: { Comment: { where: { deletedAt: null } } } }\`
- \`getMovieDetail\`: 영화 1 + 댓글 카운트 1 → 1쿼리로 통합

## Test plan
- [ ] 매치 상세에서 신청자 목록 정상 표시 (gender 포함)
- [ ] 내 신청 목록 정상 표시
- [ ] 홈 박스오피스 영화 정상 표시 (commentCount 포함)
- [ ] 영화 상세 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)