### PR TITLE
♻️ NestJS 예외/Logger 일관성 정비

### DIFF
--- a/apps/api-gateway/src/article/article.controller.ts
+++ b/apps/api-gateway/src/article/article.controller.ts
@@ -131,7 +131,7 @@ export class ArticleController {
   ) {
     const userNumber = req.user.userId;
     body.userno = userNumber;
-    this.logger.debug(`likeArticle articleId=${articleId} state=${body.state}`);
+    this.logger.debug(`likeArticle articleId=${articleId} type=${body.type}`);
     return this.articleService.likeArticle({
       articleId: Number(articleId),
       ...body,

--- a/apps/article/src/article.service.ts
+++ b/apps/article/src/article.service.ts
@@ -22,6 +22,7 @@ import {
 import { MySQLPrismaService } from '@app/prisma';
 import { UtilsService } from '@app/utils';
 import {
+  BadRequestException,
   Injectable,
   Logger,
   NotFoundException,
@@ -77,7 +78,7 @@ export class ArticleService {
       },
     });
     if (!article) {
-      throw new Error('Article not found');
+      throw new NotFoundException('Article not found');
     }
     return {
       article: {
@@ -218,13 +219,13 @@ export class ArticleService {
       },
     });
     if (!article) {
-      throw new Error('Article not found');
+      throw new NotFoundException('Article not found');
     }
     const user = await this.mysqlPrismaService.user.findUnique({
       where: { id: userno },
     });
     if (!user) {
-      throw new Error('User not found');
+      throw new NotFoundException('User not found');
     }
 
     // Return the comment object
@@ -248,7 +249,7 @@ export class ArticleService {
       include: { User: true },
     });
     if (!comment) {
-      throw new Error('Comment not found');
+      throw new NotFoundException('Comment not found');
     }
     return {
       id: comment.id,
@@ -270,7 +271,7 @@ export class ArticleService {
       data: { content },
     });
     if (!comment) {
-      throw new Error(
+      throw new NotFoundException(
         'Comment not found or you do not have permission to update it',
       );
     }
@@ -278,7 +279,7 @@ export class ArticleService {
       where: { id: userno },
     });
     if (!user) {
-      throw new Error('User not found');
+      throw new NotFoundException('User not found');
     }
 
     // Return the updated comment object
@@ -302,7 +303,7 @@ export class ArticleService {
       where: { id, userno },
     });
     if (!comment) {
-      throw new Error(
+      throw new NotFoundException(
         'Comment not found or you do not have permission to delete it',
       );
     }
@@ -361,7 +362,7 @@ export class ArticleService {
 
     switch (type) {
       case LikeType.UNRECOGNIZED:
-        throw new Error('Invalid like type');
+        throw new BadRequestException('Invalid like type');
       case LikeType.LIKE:
         likedata = 'like';
         break;

--- a/apps/chat/src/chat.gateway.ts
+++ b/apps/chat/src/chat.gateway.ts
@@ -65,7 +65,7 @@ export class ChatGateway
         createdAt: message.createdAt.toISOString(),
       });
     } catch (error) {
-      console.error('Error handling sendMessage:', error);
+      this.logger.error('Error handling sendMessage', error?.stack ?? error);
       socket.emit('error', { message: 'Failed to send message' });
     }
   }

--- a/apps/match/src/match.service.ts
+++ b/apps/match/src/match.service.ts
@@ -568,7 +568,7 @@ export class MatchService {
       );
       return response.chatRoom.id;
     } catch (error) {
-      console.error('Failed to create chat room:', error);
+      this.logger.error('Failed to create chat room', error?.stack ?? error);
       throw new BadRequestException('Failed to create chat room');
     }
   }

--- a/apps/movie/src/movie.service.ts
+++ b/apps/movie/src/movie.service.ts
@@ -12,12 +12,19 @@ import {
 } from '@app/common/protobuf';
 import { MySQLPrismaService } from '@app/prisma';
 import { UtilsService } from '@app/utils';
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleInit,
+} from '@nestjs/common';
 import axios from 'axios';
 import moment from 'moment';
 
 @Injectable()
 export class MovieService implements OnModuleInit {
+  private readonly logger = new Logger(MovieService.name);
   private readonly koficKey = process.env.KOFIC_API_KEY;
   private readonly koficUrl =
     'http://www.kobis.or.kr/kobisopenapi/webservice/rest/boxoffice/searchDailyBoxOfficeList.json';
@@ -62,7 +69,7 @@ export class MovieService implements OnModuleInit {
       });
       return response.data.results[0];
     } catch (error) {
-      console.warn(`fetchTmdbPoster failed for "${title}"`, error);
+      this.logger.warn(`fetchTmdbPoster failed for "${title}": ${error}`);
       return null;
     }
   }
@@ -107,7 +114,7 @@ export class MovieService implements OnModuleInit {
     const dateObject = new Date(formattedDate);
     const yesterday = moment().subtract(1, 'days').format('YYYYMMDD');
     if (isNaN(dateObject.getTime())) {
-      throw new Error('Invalid date provided');
+      throw new BadRequestException('Invalid date provided');
     }
 
     const isUpdated = await this.mysqlPrismaService.movie.findFirst({
@@ -130,10 +137,10 @@ export class MovieService implements OnModuleInit {
 
         await this.updateMovies(convertedMovieList);
       } else {
-        console.warn('No daily box office list found in the response.');
+        this.logger.warn('No daily box office list found in the response.');
       }
     } catch (error) {
-      console.error('Failed to fetch movies:', error);
+      this.logger.error('Failed to fetch movies', error?.stack ?? error);
     }
   }
 
@@ -174,7 +181,7 @@ export class MovieService implements OnModuleInit {
             plot = tmdbData.overview;
           }
         } catch (error) {
-          console.warn(`fetchKmdbData failed for ${movieData.movieNm}:`, error);
+          this.logger.warn(`fetchKmdbData failed for ${movieData.movieNm}: ${error}`);
         }
 
         const vector = [];
@@ -238,7 +245,7 @@ export class MovieService implements OnModuleInit {
           }
         }
       } catch (error) {
-        console.error(`Failed to upsert movie: ${movieData.movieNm}`, error);
+        this.logger.error(`Failed to upsert movie: ${movieData.movieNm}`, error?.stack ?? error);
       }
     });
 
@@ -253,7 +260,7 @@ export class MovieService implements OnModuleInit {
     const dateObject = moment(formattedDate, 'YYYYMMDD').toDate();
 
     if (isNaN(dateObject.getTime())) {
-      throw new Error('Invalid date provided');
+      throw new BadRequestException('Invalid date provided');
     }
     const movieList = await this.mysqlPrismaService.movie.findMany({
       where: {
@@ -312,7 +319,7 @@ export class MovieService implements OnModuleInit {
       !unknown.scrnCnt ||
       !unknown.showCnt
     ) {
-      throw new Error('Invalid KobisMovie data');
+      throw new BadRequestException('Invalid KobisMovie data');
     }
   }
   private convertKobisMovieData(unknown: any): KobisMovie {
@@ -418,7 +425,7 @@ export class MovieService implements OnModuleInit {
       },
     });
     if (!movie) {
-      throw new Error(`Movie with movieCd ${movieCd} not found`);
+      throw new NotFoundException(`Movie with movieCd ${movieCd} not found`);
     }
 
     return this.convertMovieDataWithCounts({


### PR DESCRIPTION
## Summary
백엔드 코드 일관성 정비 — generic Error throw를 NestJS 예외로 교체, console.* → Logger

## 변경

### 예외 정비 (HTTP 상태 코드 정상화)
- \`article.service\`: \`throw new Error\` 5건 → \`NotFoundException\`/\`BadRequestException\`
  - 기존엔 \"Article not found\" 등이 모두 500으로 응답되던 문제
- \`movie.service\`: 3건 → \`BadRequestException\`/\`NotFoundException\`

### 로깅 정비
- \`movie.service\`: console.warn/error 5건 → \`this.logger\`
- \`chat.gateway\`: console.error → this.logger.error
- \`match.service\`: console.error → this.logger.error

### 추가 버그 수정
- \`article.controller.likeArticle\`: 로그에서 존재하지 않는 \`body.state\` → \`body.type\`
  (TypeScript 컴파일 에러였음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)