### PR TITLE
♻️ article.service 도메인 분할 (478줄 → 모두 200 이하)

### DIFF
--- a/apps/article/src/article-comment.service.ts
+++ b/apps/article/src/article-comment.service.ts
@@ -1,0 +1,121 @@
+import {
+  ArticleComment,
+  CreateCommentRequest,
+  DeleteCommentRequest,
+  GetCommentRequest,
+  ListCommentsRequest,
+  ListCommentsResponse,
+  UpdateCommentRequest,
+} from '@app/common/protobuf';
+import { MySQLPrismaService } from '@app/prisma';
+import { UtilsService } from '@app/utils';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from 'prisma/generated/mysql';
+
+@Injectable()
+export class ArticleCommentService {
+  constructor(
+    private readonly prisma: MySQLPrismaService,
+    private readonly utilsService: UtilsService,
+  ) {}
+
+  private formatComment(comment: any, user: any): ArticleComment {
+    return {
+      id: comment.id,
+      articleId: comment.articleId,
+      userno: comment.userno,
+      content: comment.content,
+      createdAt: comment.createdAt.toISOString(),
+      updatedAt: comment.updatedAt.toISOString(),
+      deletedAt: this.utilsService.toNullableISOString(comment.deletedAt),
+      nickname: user.nickname,
+      avatar: user.image,
+    };
+  }
+
+  async createComment(request: CreateCommentRequest): Promise<ArticleComment> {
+    const { articleId, userno, content } = request;
+    const comment = await this.prisma.articleComments.create({
+      data: { articleId, userno, content } as Prisma.articleCommentsUncheckedCreateInput,
+    });
+    const article = await this.prisma.article.update({
+      where: { id: articleId },
+      data: { comment_count: { increment: 1 } },
+    });
+    if (!article) throw new NotFoundException('Article not found');
+
+    const user = await this.prisma.user.findUnique({ where: { id: userno } });
+    if (!user) throw new NotFoundException('User not found');
+
+    return this.formatComment(comment, user);
+  }
+
+  async getComment(request: GetCommentRequest): Promise<ArticleComment> {
+    const comment = await this.prisma.articleComments.findUnique({
+      where: { id: request.id },
+      include: { User: true },
+    });
+    if (!comment) throw new NotFoundException('Comment not found');
+    return this.formatComment(comment, comment.User);
+  }
+
+  async updateComment(request: UpdateCommentRequest): Promise<ArticleComment> {
+    const { id, userno, content } = request;
+    const comment = await this.prisma.articleComments.update({
+      where: { id, userno },
+      data: { content },
+    });
+    if (!comment) {
+      throw new NotFoundException(
+        'Comment not found or you do not have permission to update it',
+      );
+    }
+    const user = await this.prisma.user.findUnique({ where: { id: userno } });
+    if (!user) throw new NotFoundException('User not found');
+
+    return this.formatComment(comment, user);
+  }
+
+  async deleteComment(request: DeleteCommentRequest): Promise<void> {
+    const { id, userno } = request;
+    const comment = await this.prisma.articleComments.findUnique({
+      where: { id, userno },
+    });
+    if (!comment) {
+      throw new NotFoundException(
+        'Comment not found or you do not have permission to delete it',
+      );
+    }
+
+    await this.prisma.article.update({
+      where: { id: comment.articleId },
+      data: { comment_count: { decrement: 1 } },
+    });
+    await this.prisma.articleComments.update({
+      where: { id, userno },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  async listComments(
+    request: ListCommentsRequest,
+  ): Promise<ListCommentsResponse> {
+    const { articleId, page, pageSize } = request;
+    const comments = await this.prisma.articleComments.findMany({
+      where: { articleId, deletedAt: null },
+      include: { User: true },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      orderBy: { createdAt: 'desc' },
+    });
+    const totalCount = await this.prisma.articleComments.count({
+      where: { articleId, deletedAt: null },
+    });
+
+    return {
+      comments: comments.map((c) => this.formatComment(c, c.User)),
+      totalCount,
+      hasNext: totalCount > page * pageSize,
+    };
+  }
+}

--- a/apps/article/src/article-crud.service.ts
+++ b/apps/article/src/article-crud.service.ts
@@ -1,0 +1,117 @@
+import {
+  CreateArticleRequest,
+  CreateArticleResponse,
+  DeleteArticleRequest,
+  ListArticlesRequest,
+  ListArticlesResponse,
+  UpdateArticleRequest,
+} from '@app/common/protobuf';
+import { MySQLPrismaService } from '@app/prisma';
+import { UtilsService } from '@app/utils';
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { GetArticleRequest } from 'proto/article';
+
+@Injectable()
+export class ArticleCrudService {
+  private readonly logger = new Logger(ArticleCrudService.name);
+  constructor(
+    private readonly prisma: MySQLPrismaService,
+    private readonly utilsService: UtilsService,
+  ) {}
+
+  private formatArticle(article: any) {
+    return {
+      id: article.id,
+      userno: article.userno,
+      title: article.title,
+      author: article.User.nickname,
+      content: article.content,
+      likeCount: article.like_count,
+      dislikeCount: article.dislike_count,
+      commentCount: article.comment_count,
+      createdAt: article.createdAt.toISOString(),
+      updatedAt: article.updatedAt.toISOString(),
+      deletedAt: this.utilsService.toNullableISOString(article.deletedAt),
+    };
+  }
+
+  async createArticle(
+    request: CreateArticleRequest,
+  ): Promise<CreateArticleResponse> {
+    const { title, content, userno } = request;
+    const article = await this.prisma.article.create({
+      data: { title, content, userno },
+      include: { User: true },
+    });
+    return { article: this.formatArticle(article) };
+  }
+
+  async getArticle(request: GetArticleRequest): Promise<CreateArticleResponse> {
+    const article = await this.prisma.article.findUnique({
+      where: { id: request.id },
+      include: { User: true },
+    });
+    if (!article) throw new NotFoundException('Article not found');
+    return { article: this.formatArticle(article) };
+  }
+
+  async listArticles(
+    request: ListArticlesRequest,
+  ): Promise<ListArticlesResponse> {
+    const { page, pageSize } = request;
+    const articles = await this.prisma.article.findMany({
+      where: { deletedAt: null },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: { User: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    const totalCount = await this.prisma.article.count({
+      where: { deletedAt: null },
+    });
+    return {
+      articles: articles.map((a) => this.formatArticle(a)),
+      hasNext: totalCount > page * pageSize,
+    };
+  }
+
+  async updateArticle(
+    request: UpdateArticleRequest,
+  ): Promise<CreateArticleResponse> {
+    const { id, userno, title, content } = request;
+
+    const existing = await this.prisma.article.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundException('Article not found');
+    if (existing.userno !== userno) {
+      throw new ForbiddenException('You can only update your own articles');
+    }
+
+    const article = await this.prisma.article.update({
+      where: { id },
+      data: { title, content, updatedAt: new Date() },
+      include: { User: true },
+    });
+    return { article: this.formatArticle(article) };
+  }
+
+  async deleteArticle(request: DeleteArticleRequest): Promise<void> {
+    const { id, userno } = request;
+    this.logger.log(`deleteArticle id=${id} userId=${userno}`);
+
+    const existing = await this.prisma.article.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundException('Article not found');
+    if (existing.userno !== userno) {
+      throw new ForbiddenException('You can only delete your own articles');
+    }
+
+    await this.prisma.article.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+}

--- a/apps/article/src/article-like.service.ts
+++ b/apps/article/src/article-like.service.ts
@@ -1,0 +1,99 @@
+import { assertNever } from '@app/common/entity';
+import {
+  ArticleLike,
+  GetArticleLikeStatsRequest,
+  GetArticleLikeStatsResponse,
+  LikeArticleRequest,
+  LikeType,
+} from '@app/common/protobuf';
+import { MySQLPrismaService } from '@app/prisma';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Prisma } from 'prisma/generated/mysql';
+
+@Injectable()
+export class ArticleLikeService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async likeArticle(request: LikeArticleRequest): Promise<ArticleLike> {
+    const { articleId, userno, type } = request;
+    const likedata = this.toLikeKind(type);
+
+    const existingLike = await this.prisma.articleLikes.findFirst({
+      where: { article_id: articleId, userno, type: likedata },
+    });
+
+    if (existingLike) {
+      await this.prisma.articleLikes.delete({ where: { id: existingLike.id } });
+      await this.adjustCount(articleId, likedata, -1);
+      return this.formatLike(existingLike);
+    }
+
+    const like = await this.prisma.articleLikes.create({
+      data: { article_id: articleId, userno, type: likedata } as Prisma.articleLikesUncheckedCreateInput,
+    });
+    await this.adjustCount(articleId, likedata, 1);
+    return this.formatLike(like);
+  }
+
+  async getArticleLikeStats(
+    request: GetArticleLikeStatsRequest,
+  ): Promise<GetArticleLikeStatsResponse> {
+    const { articleId, userno } = request;
+    const [hasLike, hasDislike] = await Promise.all([
+      this.prisma.articleLikes.count({
+        where: { article_id: articleId, type: 'like', userno },
+      }),
+      this.prisma.articleLikes.count({
+        where: { article_id: articleId, type: 'dislike', userno },
+      }),
+    ]);
+    return {
+      userno,
+      articleId,
+      hasLiked: hasLike > 0,
+      hasDisliked: hasDislike > 0,
+    };
+  }
+
+  private toLikeKind(type: LikeType): 'like' | 'dislike' {
+    switch (type) {
+      case LikeType.UNRECOGNIZED:
+        throw new BadRequestException('Invalid like type');
+      case LikeType.LIKE:
+        return 'like';
+      case LikeType.DISLIKE:
+        return 'dislike';
+      default:
+        assertNever(type);
+    }
+  }
+
+  private async adjustCount(
+    articleId: number,
+    likedata: 'like' | 'dislike',
+    delta: 1 | -1,
+  ) {
+    const op = delta === 1 ? 'increment' : 'decrement';
+    if (likedata === 'like') {
+      await this.prisma.article.update({
+        where: { id: articleId },
+        data: { like_count: { [op]: 1 } },
+      });
+    } else {
+      await this.prisma.article.update({
+        where: { id: articleId },
+        data: { dislike_count: { [op]: 1 } },
+      });
+    }
+  }
+
+  private formatLike(like: any): ArticleLike {
+    return {
+      id: like.id,
+      articleId: like.article_id,
+      userno: like.userno,
+      type: like.type === 'like' ? LikeType.LIKE : LikeType.DISLIKE,
+      createdAt: like.createdAt.toISOString(),
+    };
+  }
+}

--- a/apps/article/src/article.module.ts
+++ b/apps/article/src/article.module.ts
@@ -1,12 +1,20 @@
 import { Module } from '@nestjs/common';
 import { ArticleController } from './article.controller';
 import { ArticleService } from './article.service';
+import { ArticleCrudService } from './article-crud.service';
+import { ArticleCommentService } from './article-comment.service';
+import { ArticleLikeService } from './article-like.service';
 import { PrismaModule } from '@app/prisma';
 import { UtilsModule } from '@app/utils';
 
 @Module({
   imports: [PrismaModule, UtilsModule],
   controllers: [ArticleController],
-  providers: [ArticleService],
+  providers: [
+    ArticleService,
+    ArticleCrudService,
+    ArticleCommentService,
+    ArticleLikeService,
+  ],
 })
 export class ArticleModule {}

--- a/apps/article/src/article.service.ts
+++ b/apps/article/src/article.service.ts
@@ -1,479 +1,69 @@
-import { assertNever } from '@app/common/entity';
+import { Injectable } from '@nestjs/common';
 import {
-  ArticleComment,
-  ArticleLike,
   CreateArticleRequest,
-  CreateArticleResponse,
   CreateCommentRequest,
   DeleteArticleRequest,
   DeleteCommentRequest,
   GetArticleLikeStatsRequest,
-  GetArticleLikeStatsResponse,
   GetCommentRequest,
   LikeArticleRequest,
-  LikeType,
   ListArticlesRequest,
-  ListArticlesResponse,
   ListCommentsRequest,
-  ListCommentsResponse,
   UpdateArticleRequest,
   UpdateCommentRequest,
 } from '@app/common/protobuf';
-import { MySQLPrismaService } from '@app/prisma';
-import { UtilsService } from '@app/utils';
-import {
-  BadRequestException,
-  Injectable,
-  Logger,
-  NotFoundException,
-  ForbiddenException,
-} from '@nestjs/common';
-import { Prisma } from 'prisma/generated/mysql';
 import { GetArticleRequest } from 'proto/article';
+import { ArticleCrudService } from './article-crud.service';
+import { ArticleCommentService } from './article-comment.service';
+import { ArticleLikeService } from './article-like.service';
 
 @Injectable()
 export class ArticleService {
-  private readonly logger = new Logger(ArticleService.name);
   constructor(
-    private readonly mysqlPrismaService: MySQLPrismaService,
-    private readonly utilsService: UtilsService,
+    private readonly crud: ArticleCrudService,
+    private readonly commentService: ArticleCommentService,
+    private readonly likeService: ArticleLikeService,
   ) {}
-  async createArticle(
-    request: CreateArticleRequest,
-  ): Promise<CreateArticleResponse> {
-    const { title, content, userno } = request;
-    const article = await this.mysqlPrismaService.article.create({
-      data: {
-        title,
-        content,
-        userno,
-      },
-      include: {
-        User: true,
-      },
-    });
-    return {
-      article: {
-        id: article.id,
-        userno: article.userno,
-        title: article.title,
-        author: article.User.nickname,
-        content: article.content,
-        likeCount: article.like_count,
-        dislikeCount: article.dislike_count,
-        commentCount: article.comment_count,
-        createdAt: article.createdAt.toISOString(),
-        updatedAt: article.updatedAt.toISOString(),
-        deletedAt: this.utilsService.toNullableISOString(article.deletedAt),
-      },
-    };
+
+  // Article CRUD
+  createArticle(req: CreateArticleRequest) {
+    return this.crud.createArticle(req);
+  }
+  getArticle(req: GetArticleRequest) {
+    return this.crud.getArticle(req);
+  }
+  listArticles(req: ListArticlesRequest) {
+    return this.crud.listArticles(req);
+  }
+  updateArticle(req: UpdateArticleRequest) {
+    return this.crud.updateArticle(req);
+  }
+  deleteArticle(req: DeleteArticleRequest) {
+    return this.crud.deleteArticle(req);
   }
 
-  async getArticle(request: GetArticleRequest): Promise<CreateArticleResponse> {
-    const { id } = request;
-    const article = await this.mysqlPrismaService.article.findUnique({
-      where: { id },
-      include: {
-        User: true,
-      },
-    });
-    if (!article) {
-      throw new NotFoundException('Article not found');
-    }
-    return {
-      article: {
-        id: article.id,
-        userno: article.userno,
-        title: article.title,
-        author: article.User.nickname,
-        content: article.content,
-        likeCount: article.like_count,
-        dislikeCount: article.dislike_count,
-        commentCount: article.comment_count,
-        createdAt: article.createdAt.toISOString(),
-        updatedAt: article.updatedAt.toISOString(),
-        deletedAt: this.utilsService.toNullableISOString(article.deletedAt),
-      },
-    };
+  // Comments
+  createComment(req: CreateCommentRequest) {
+    return this.commentService.createComment(req);
+  }
+  getComment(req: GetCommentRequest) {
+    return this.commentService.getComment(req);
+  }
+  updateComment(req: UpdateCommentRequest) {
+    return this.commentService.updateComment(req);
+  }
+  deleteComment(req: DeleteCommentRequest) {
+    return this.commentService.deleteComment(req);
+  }
+  listComments(req: ListCommentsRequest) {
+    return this.commentService.listComments(req);
   }
 
-  async listArticles(
-    request: ListArticlesRequest,
-  ): Promise<ListArticlesResponse> {
-    const { page, pageSize } = request;
-    const articles = await this.mysqlPrismaService.article.findMany({
-      where: { deletedAt: null },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-      include: {
-        User: true,
-      },
-      orderBy: { createdAt: 'desc' },
-    });
-    const totalCount = await this.mysqlPrismaService.article.count({
-      where: { deletedAt: null },
-    });
-    const hasNext = totalCount > page * pageSize;
-
-    return {
-      articles: articles.map((article) => ({
-        id: article.id,
-        userno: article.userno,
-        author: article.User.nickname,
-        title: article.title,
-        content: article.content,
-        likeCount: article.like_count,
-        dislikeCount: article.dislike_count,
-        commentCount: article.comment_count,
-        createdAt: article.createdAt.toISOString(),
-        updatedAt: article.updatedAt.toISOString(),
-        deletedAt: this.utilsService.toNullableISOString(article.deletedAt),
-      })),
-      hasNext,
-    };
+  // Likes
+  likeArticle(req: LikeArticleRequest) {
+    return this.likeService.likeArticle(req);
   }
-
-  async updateArticle(
-    request: UpdateArticleRequest,
-  ): Promise<CreateArticleResponse> {
-    const { id, userno, title, content } = request;
-
-    // 기존 게시글 조회 및 권한 확인
-    const existingArticle = await this.mysqlPrismaService.article.findUnique({
-      where: { id },
-    });
-
-    if (!existingArticle) {
-      throw new NotFoundException('Article not found');
-    }
-
-    if (existingArticle.userno !== userno) {
-      throw new ForbiddenException('You can only update your own articles');
-    }
-
-    const article = await this.mysqlPrismaService.article.update({
-      where: { id },
-      data: {
-        title,
-        content,
-        updatedAt: new Date(),
-      },
-      include: {
-        User: true,
-      },
-    });
-    return {
-      article: {
-        id: article.id,
-        author: article.User.nickname,
-        userno: article.userno,
-        title: article.title,
-        content: article.content,
-        likeCount: article.like_count,
-        dislikeCount: article.dislike_count,
-        commentCount: article.comment_count,
-        createdAt: article.createdAt.toISOString(),
-        updatedAt: article.updatedAt.toISOString(),
-        deletedAt: this.utilsService.toNullableISOString(article.deletedAt),
-      },
-    };
-  }
-  async deleteArticle(request: DeleteArticleRequest): Promise<void> {
-    const { id, userno } = request;
-    this.logger.log(`deleteArticle id=${id} userId=${userno}`);
-
-    // 기존 게시글 조회 및 권한 확인
-    const existingArticle = await this.mysqlPrismaService.article.findUnique({
-      where: { id },
-    });
-
-    if (!existingArticle) {
-      throw new NotFoundException('Article not found');
-    }
-
-    if (existingArticle.userno !== userno) {
-      throw new ForbiddenException('You can only delete your own articles');
-    }
-
-    // soft delete
-    await this.mysqlPrismaService.article.update({
-      where: { id },
-      data: { deletedAt: new Date() },
-    });
-  }
-  async createComment(request: CreateCommentRequest): Promise<ArticleComment> {
-    const { articleId, userno, content } = request;
-    const comment = await this.mysqlPrismaService.articleComments.create({
-      data: {
-        articleId,
-        userno: userno,
-        content,
-      } as Prisma.articleCommentsUncheckedCreateInput,
-    });
-    const article = await this.mysqlPrismaService.article.update({
-      where: { id: articleId },
-      data: {
-        comment_count: {
-          increment: 1,
-        },
-      },
-    });
-    if (!article) {
-      throw new NotFoundException('Article not found');
-    }
-    const user = await this.mysqlPrismaService.user.findUnique({
-      where: { id: userno },
-    });
-    if (!user) {
-      throw new NotFoundException('User not found');
-    }
-
-    // Return the comment object
-    return {
-      id: comment.id,
-      articleId: comment.articleId,
-      userno: comment.userno,
-      content: comment.content,
-      createdAt: comment.createdAt.toISOString(),
-      updatedAt: comment.updatedAt.toISOString(),
-      deletedAt: comment.deletedAt?.toISOString() ?? null,
-      nickname: user.nickname,
-      avatar: user.image,
-    };
-  }
-
-  async getComment(request: GetCommentRequest): Promise<ArticleComment> {
-    const { id } = request;
-    const comment = await this.mysqlPrismaService.articleComments.findUnique({
-      where: { id },
-      include: { User: true },
-    });
-    if (!comment) {
-      throw new NotFoundException('Comment not found');
-    }
-    return {
-      id: comment.id,
-      articleId: comment.articleId,
-      userno: comment.userno,
-      content: comment.content,
-      createdAt: comment.createdAt.toISOString(),
-      updatedAt: comment.updatedAt.toISOString(),
-      deletedAt: comment.deletedAt?.toISOString() ?? null,
-      nickname: comment.User.nickname,
-      avatar: comment.User.image,
-    };
-  }
-
-  async updateComment(request: UpdateCommentRequest): Promise<ArticleComment> {
-    const { id, userno, content } = request;
-    const comment = await this.mysqlPrismaService.articleComments.update({
-      where: { id, userno },
-      data: { content },
-    });
-    if (!comment) {
-      throw new NotFoundException(
-        'Comment not found or you do not have permission to update it',
-      );
-    }
-    const user = await this.mysqlPrismaService.user.findUnique({
-      where: { id: userno },
-    });
-    if (!user) {
-      throw new NotFoundException('User not found');
-    }
-
-    // Return the updated comment object
-    return {
-      id: comment.id,
-      articleId: comment.articleId,
-      userno: comment.userno,
-      content: comment.content,
-      createdAt: comment.createdAt.toISOString(),
-      updatedAt: comment.updatedAt.toISOString(),
-      deletedAt: comment.deletedAt?.toISOString() ?? null,
-      nickname: user.nickname,
-      avatar: user.image,
-    };
-  }
-
-  async deleteComment(request: DeleteCommentRequest): Promise<void> {
-    const { id, userno } = request;
-
-    const comment = await this.mysqlPrismaService.articleComments.findUnique({
-      where: { id, userno },
-    });
-    if (!comment) {
-      throw new NotFoundException(
-        'Comment not found or you do not have permission to delete it',
-      );
-    }
-
-    await this.mysqlPrismaService.article.update({
-      where: { id: comment.articleId },
-      data: {
-        comment_count: {
-          decrement: 1,
-        },
-      },
-    });
-
-    await this.mysqlPrismaService.articleComments.update({
-      where: { id, userno },
-      data: { deletedAt: new Date() },
-    });
-  }
-  async listComments(
-    request: ListCommentsRequest,
-  ): Promise<ListCommentsResponse> {
-    const { articleId, page, pageSize } = request;
-    const comments = await this.mysqlPrismaService.articleComments.findMany({
-      where: { articleId, deletedAt: null },
-      include: { User: true },
-      skip: (page - 1) * pageSize,
-      take: pageSize,
-      orderBy: { createdAt: 'desc' },
-    });
-    const totalCount = await this.mysqlPrismaService.articleComments.count({
-      where: { articleId, deletedAt: null },
-    });
-    const hasNext = totalCount > page * pageSize;
-
-    return {
-      comments: comments.map((comment) => ({
-        id: comment.id,
-        articleId: comment.articleId,
-        userno: comment.userno,
-        content: comment.content,
-        createdAt: comment.createdAt.toISOString(),
-        updatedAt: comment.updatedAt.toISOString(),
-        deletedAt: this.utilsService.toNullableISOString(comment.deletedAt),
-        nickname: comment.User.nickname,
-        avatar: comment.User.image,
-      })),
-      totalCount,
-      hasNext,
-    };
-  }
-
-  async likeArticle(request: LikeArticleRequest): Promise<ArticleLike> {
-    const { articleId, userno, type } = request;
-
-    let likedata: 'like' | 'dislike';
-
-    switch (type) {
-      case LikeType.UNRECOGNIZED:
-        throw new BadRequestException('Invalid like type');
-      case LikeType.LIKE:
-        likedata = 'like';
-        break;
-      case LikeType.DISLIKE:
-        likedata = 'dislike';
-        break;
-      default:
-        assertNever(type);
-    }
-    const existingLike = await this.mysqlPrismaService.articleLikes.findFirst({
-      where: {
-        article_id: articleId,
-        userno,
-        type: likedata,
-      },
-    });
-    if (existingLike) {
-      // 좋아요/싫어요 취소: 레코드 삭제 및 카운트 감소
-      await this.mysqlPrismaService.articleLikes.delete({
-        where: {
-          id: existingLike.id,
-        },
-      });
-      if (likedata === 'like') {
-        await this.mysqlPrismaService.article.update({
-          where: { id: articleId },
-          data: {
-            like_count: {
-              decrement: 1,
-            },
-          },
-        });
-      } else {
-        await this.mysqlPrismaService.article.update({
-          where: { id: articleId },
-          data: {
-            dislike_count: {
-              decrement: 1,
-            },
-          },
-        });
-      }
-      return {
-        id: existingLike.id,
-        articleId: existingLike.article_id,
-        userno: existingLike.userno,
-        type: existingLike.type === 'like' ? LikeType.LIKE : LikeType.DISLIKE,
-        createdAt: existingLike.createdAt.toISOString(),
-      };
-    }
-
-    const like = await this.mysqlPrismaService.articleLikes.create({
-      data: {
-        article_id: articleId,
-        userno,
-        type: likedata,
-      } as Prisma.articleLikesUncheckedCreateInput,
-    });
-    if (likedata === 'like') {
-      await this.mysqlPrismaService.article.update({
-        where: { id: articleId },
-        data: {
-          like_count: {
-            increment: 1,
-          },
-        },
-      });
-    } else {
-      await this.mysqlPrismaService.article.update({
-        where: { id: articleId },
-        data: {
-          dislike_count: {
-            increment: 1,
-          },
-        },
-      });
-    }
-
-    const liketype = like.type === 'like' ? LikeType.LIKE : LikeType.DISLIKE;
-    return {
-      id: like.id,
-      articleId: like.article_id,
-      userno: like.userno,
-      type: liketype,
-      createdAt: like.createdAt.toISOString(),
-    };
-  }
-
-  async getArticleLikeStats(
-    request: GetArticleLikeStatsRequest,
-  ): Promise<GetArticleLikeStatsResponse> {
-    const { articleId, userno } = request;
-    const hasLike = await this.mysqlPrismaService.articleLikes.count({
-      where: {
-        article_id: articleId,
-        type: 'like',
-        userno: userno,
-      },
-    });
-    const hasDislike = await this.mysqlPrismaService.articleLikes.count({
-      where: {
-        article_id: articleId,
-        type: 'dislike',
-        userno: userno,
-      },
-    });
-    return {
-      userno: userno,
-      articleId: articleId,
-      hasLiked: hasLike > 0 ? true : false,
-      hasDisliked: hasDislike > 0 ? true : false,
-    };
+  getArticleLikeStats(req: GetArticleLikeStatsRequest) {
+    return this.likeService.getArticleLikeStats(req);
   }
 }


### PR DESCRIPTION
## Summary
article.service.ts 478줄을 도메인별로 분할 — 모든 파일이 200줄 이하

## 변경
| 파일 | 줄수 | 책임 |
|------|------|------|
| \`article.service.ts\` | 69 | 파사드 |
| \`article-crud.service.ts\` | 117 | 게시글 CRUD |
| \`article-comment.service.ts\` | 121 | 댓글 CRUD |
| \`article-like.service.ts\` | 99 | 좋아요/싫어요 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)