### PR TITLE
ci: SSH 배포 command_timeout 30m으로 확장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: 22
+          command_timeout: 30m
           envs: GHCR_TOKEN,GITHUB_ACTOR
           script: |
             set -e


### PR DESCRIPTION
appleboy/ssh-action 기본 10m timeout 초과 방지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)