### PR TITLE
🐛 영화별 매칭 목록 필터 추가

### DIFF
--- a/apps/api-gateway/src/match/match.controller.ts
+++ b/apps/api-gateway/src/match/match.controller.ts
@@ -30,10 +30,12 @@ export class MatchController {
   async getMatchPosts(
     @Query('page') page: string,
     @Query('pageSize') pageSize: string,
+    @Query('movieTitle') movieTitle: string,
   ) {
     return this.matchService.getMatchPosts({
       page: Number(page) || 1,
       pageSize: Number(pageSize) || 10,
+      movieTitle: movieTitle?.trim() || '',
     });
   }
 

--- a/apps/match/src/match-post.service.ts
+++ b/apps/match/src/match-post.service.ts
@@ -35,11 +35,17 @@ export class MatchPostService {
   async getMatchPosts(
     request: GetMatchPostsRequest,
   ): Promise<MatchPostResponse> {
-    const { page = 1, pageSize = 10 } = request;
+    const { page = 1, pageSize = 10, movieTitle } = request;
     const skip = (page - 1) * pageSize;
+    const trimmedMovieTitle = movieTitle?.trim();
 
     const matchPosts = await this.prisma.matchPost.findMany({
-      where: { deletedAt: null },
+      where: {
+        deletedAt: null,
+        ...(trimmedMovieTitle
+          ? { movieTitle: { contains: trimmedMovieTitle } }
+          : {}),
+      },
       include: POST_INCLUDE,
       orderBy: { createdAt: 'desc' },
       skip,

--- a/libs/common/src/protobuf/match.ts
+++ b/libs/common/src/protobuf/match.ts
@@ -39,6 +39,7 @@ export interface MatchApplication {
 export interface GetMatchPostsRequest {
   page: number;
   pageSize: number;
+  movieTitle: string;
 }
 
 export interface CreateMatchPostRequest {

--- a/proto/match.proto
+++ b/proto/match.proto
@@ -36,6 +36,7 @@ message MatchApplication {
 message GetMatchPostsRequest {
   int32 page = 1;
   int32 pageSize = 2;
+  string movieTitle = 3;
 }
 
 message CreateMatchPostRequest {


### PR DESCRIPTION
## Summary
영화 상세에서 넘어온 `movieTitle` 쿼리로 매칭 목록을 서버에서 필터링할 수 있게 합니다.

## 원인
TASK-6 진행 전 확인 결과 매칭 목록 API가 page/pageSize만 처리해 영화별 매칭 목록을 정확히 내려줄 수 없었습니다.

## 변경
- `GetMatchPostsRequest`에 `movieTitle` 필드 추가
- API Gateway `GET /match`에서 `movieTitle` 쿼리 전달
- match 서비스 목록 조회 조건에 `movieTitle contains` 필터 추가

## Test plan
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/match/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 점검 (`libs/common/src/protobuf/match.ts`는 gRPC stub 예외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)