### PR TITLE
🐛 매칭 목록 서버 필터 추가

### DIFF
--- a/apps/api-gateway/src/match/match.controller.ts
+++ b/apps/api-gateway/src/match/match.controller.ts
@@ -31,11 +31,15 @@ export class MatchController {
     @Query('page') page: string,
     @Query('pageSize') pageSize: string,
     @Query('movieTitle') movieTitle: string,
+    @Query('filter') filter: string,
+    @Query('userno') userno: string,
   ) {
     return this.matchService.getMatchPosts({
       page: Number(page) || 1,
       pageSize: Number(pageSize) || 10,
       movieTitle: movieTitle?.trim() || '',
+      filter: filter?.trim() || '',
+      userno: Number(userno) || 0,
     });
   }
 

--- a/apps/match/src/match-post.filters.ts
+++ b/apps/match/src/match-post.filters.ts
@@ -1,0 +1,41 @@
+import { GetMatchPostsRequest } from '@app/common/protobuf';
+
+function getWeekRange() {
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 7);
+
+  return {
+    start: start.toISOString().slice(0, 10),
+    end: end.toISOString().slice(0, 10),
+  };
+}
+
+export function buildMatchPostWhere(request: GetMatchPostsRequest) {
+  const { movieTitle, filter, userno } = request;
+  const trimmedMovieTitle = movieTitle?.trim();
+  const weekRange = filter === 'week' ? getWeekRange() : null;
+
+  return {
+    deletedAt: null,
+    ...(trimmedMovieTitle
+      ? { movieTitle: { contains: trimmedMovieTitle } }
+      : {}),
+    ...(filter === 'week' && weekRange
+      ? { showTime: { gte: weekRange.start, lte: weekRange.end } }
+      : {}),
+    ...(filter === 'mine' && userno ? { userno } : {}),
+  };
+}
+
+export function isAvailablePost(post: {
+  maxParticipants: number;
+  _count: { MatchApplication: number };
+}) {
+  return post._count.MatchApplication < post.maxParticipants;
+}
+
+export function paginate<T>(items: T[], skip: number, pageSize: number) {
+  return items.slice(skip, skip + pageSize);
+}

--- a/apps/match/src/match-post.service.ts
+++ b/apps/match/src/match-post.service.ts
@@ -17,6 +17,11 @@ import {
   CommonResponse,
 } from '@app/common/protobuf';
 import { formatMatchPost } from './match.formatter';
+import {
+  buildMatchPostWhere,
+  isAvailablePost,
+  paginate,
+} from './match-post.filters';
 
 const POST_INCLUDE = {
   User: true,
@@ -35,17 +40,30 @@ export class MatchPostService {
   async getMatchPosts(
     request: GetMatchPostsRequest,
   ): Promise<MatchPostResponse> {
-    const { page = 1, pageSize = 10, movieTitle } = request;
+    const { page = 1, pageSize = 10, filter, userno } = request;
     const skip = (page - 1) * pageSize;
-    const trimmedMovieTitle = movieTitle?.trim();
+    if (filter === 'mine' && !userno) {
+      return { matchPosts: [], hasNext: false };
+    }
+    const where = buildMatchPostWhere(request);
+
+    if (filter === 'available') {
+      const allPosts = await this.prisma.matchPost.findMany({
+        where,
+        include: POST_INCLUDE,
+        orderBy: { createdAt: 'desc' },
+      });
+      const availablePosts = allPosts.filter(isAvailablePost);
+      const pagePosts = paginate(availablePosts, skip, pageSize);
+
+      return {
+        matchPosts: pagePosts.map(formatMatchPost),
+        hasNext: availablePosts.length > skip + pageSize,
+      };
+    }
 
     const matchPosts = await this.prisma.matchPost.findMany({
-      where: {
-        deletedAt: null,
-        ...(trimmedMovieTitle
-          ? { movieTitle: { contains: trimmedMovieTitle } }
-          : {}),
-      },
+      where,
       include: POST_INCLUDE,
       orderBy: { createdAt: 'desc' },
       skip,

--- a/libs/common/src/protobuf/match.ts
+++ b/libs/common/src/protobuf/match.ts
@@ -40,6 +40,8 @@ export interface GetMatchPostsRequest {
   page: number;
   pageSize: number;
   movieTitle: string;
+  filter: string;
+  userno: number;
 }
 
 export interface CreateMatchPostRequest {

--- a/proto/match.proto
+++ b/proto/match.proto
@@ -37,6 +37,8 @@ message GetMatchPostsRequest {
   int32 page = 1;
   int32 pageSize = 2;
   string movieTitle = 3;
+  string filter = 4;
+  int32 userno = 5;
 }
 
 message CreateMatchPostRequest {


### PR DESCRIPTION
## Summary
매칭 목록의 모집중/이번주/내매칭 필터를 서버 쿼리에서 처리할 수 있게 합니다.

## 원인
기존 필터는 프론트에 로드된 페이지만 대상으로 동작해 전체 데이터 기준 결과와 페이지네이션이 어긋날 수 있었습니다.

## 변경
- `GetMatchPostsRequest`에 `filter`, `userno` 추가
- API Gateway `GET /match`에서 필터 쿼리 전달
- match 서비스에서 `available`, `week`, `mine` 필터 처리
- `available`은 accepted 신청 count 기준으로 서버에서 필터 후 페이지네이션

## Test plan
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/match/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 점검 (`libs/common/src/protobuf/match.ts`는 gRPC stub 예외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)