### PR TITLE
🐛 OAuth 신규 사용자 반환값 수정

### DIFF
--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -1,7 +1,6 @@
 import { OutOfRangeException } from '@app/common/filters/rpcexception/rpc-exception';
 import { AuthCommonResponse, User, ValidationResponse } from '@app/common/protobuf';
 import { MySQLPrismaService } from '@app/prisma';
-import { UtilsService } from '@app/utils';
 import { Injectable, Logger } from '@nestjs/common';
 import { randomBytes } from 'crypto';
 import { compare, hash } from 'bcryptjs';
@@ -21,7 +20,6 @@ export class AuthService {
 
   constructor(
     private readonly mysqlPrismaService: MySQLPrismaService,
-    private readonly utilsService: UtilsService,
     private readonly emailService: EmailService,
   ) {}
 
@@ -69,11 +67,9 @@ export class AuthService {
         email: newUser.email,
         nickname: newUser.nickname,
         image: newUser.image,
-        createdAt: this.utilsService.dateToTimestamp(newUser.createdAt as Date),
-        updatedAt: this.utilsService.dateToTimestamp(newUser.updatedAt as Date),
-        deletedAt: newUser.deletedAt
-          ? this.utilsService.dateToTimestamp(newUser.deletedAt as Date)
-          : null,
+        createdAt: newUser.createdAt.toISOString(),
+        updatedAt: newUser.updatedAt.toISOString(),
+        deletedAt: newUser.deletedAt ? newUser.deletedAt.toISOString() : null,
         gender: newUser.gender,
       } as User;
     }


### PR DESCRIPTION
## Summary
Google OAuth 신규 사용자 생성 후 프론트에서 AccessDenied가 발생하는 백엔드 응답 shape를 수정합니다.

## 원인
- OAuth 신규 사용자 생성 경로는 `createdAt`, `updatedAt`, `deletedAt`을 protobuf Timestamp 객체로 반환했습니다.
- API Gateway `convertToUserEntity`는 날짜 필드를 문자열로 검증하므로 신규 OAuth 사용자에서 `Invalid user`가 발생했습니다.
- 프론트 NextAuth signIn 콜백은 백엔드 OAuth 실패를 AccessDenied로 표시했습니다.

## 변경
- OAuth 신규 사용자 반환 날짜를 기존 사용자 경로와 동일하게 ISO 문자열로 통일
- 더 이상 사용하지 않는 `UtilsService` 주입 제거

## Test plan
- [x] `pnpm exec tsc -p apps/auth/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인: 191줄
- [ ] `api-gateway` 타입체크는 기존 Prisma notification 타입 생성 누락으로 실패함

🤖 Generated with [Codex](https://openai.com/codex)