### PR TITLE
🚀 Release: OAuth 신규 사용자 응답 수정

### DIFF
--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -1,7 +1,6 @@
 import { OutOfRangeException } from '@app/common/filters/rpcexception/rpc-exception';
 import { AuthCommonResponse, User, ValidationResponse } from '@app/common/protobuf';
 import { MySQLPrismaService } from '@app/prisma';
-import { UtilsService } from '@app/utils';
 import { Injectable, Logger } from '@nestjs/common';
 import { randomBytes } from 'crypto';
 import { compare, hash } from 'bcryptjs';
@@ -21,7 +20,6 @@ export class AuthService {
 
   constructor(
     private readonly mysqlPrismaService: MySQLPrismaService,
-    private readonly utilsService: UtilsService,
     private readonly emailService: EmailService,
   ) {}
 
@@ -69,11 +67,9 @@ export class AuthService {
         email: newUser.email,
         nickname: newUser.nickname,
         image: newUser.image,
-        createdAt: this.utilsService.dateToTimestamp(newUser.createdAt as Date),
-        updatedAt: this.utilsService.dateToTimestamp(newUser.updatedAt as Date),
-        deletedAt: newUser.deletedAt
-          ? this.utilsService.dateToTimestamp(newUser.deletedAt as Date)
-          : null,
+        createdAt: newUser.createdAt.toISOString(),
+        updatedAt: newUser.updatedAt.toISOString(),
+        deletedAt: newUser.deletedAt ? newUser.deletedAt.toISOString() : null,
         gender: newUser.gender,
       } as User;
     }


### PR DESCRIPTION
## Summary
Google OAuth 신규 사용자 AccessDenied 수정 사항을 프로덕션 배포 대상으로 올립니다.

## 변경
- PR #74 — OAuth 신규 사용자 반환 날짜를 API Gateway 검증 형식에 맞게 ISO 문자열로 통일

## Test plan
- [x] `pnpm exec tsc -p apps/auth/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 Google OAuth 신규/초기 사용자 로그인 확인

## Note
- `api-gateway` 타입체크는 기존 Prisma notification 타입 생성 누락으로 실패합니다. 이번 OAuth 변경과 별개입니다.

🤖 Generated with [Codex](https://openai.com/codex)