### PR TITLE
🚀 Hotfix: OAuth 신규 사용자 AccessDenied

### DIFF
--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -1,7 +1,6 @@
 import { OutOfRangeException } from '@app/common/filters/rpcexception/rpc-exception';
 import { AuthCommonResponse, User, ValidationResponse } from '@app/common/protobuf';
 import { MySQLPrismaService } from '@app/prisma';
-import { UtilsService } from '@app/utils';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { randomBytes } from 'crypto';
 import { compare, hash } from 'bcryptjs';
@@ -18,7 +17,6 @@ export class AuthService {
   constructor(
     @Inject('REDIS') private readonly redis: Redis,
     private readonly mysqlPrismaService: MySQLPrismaService,
-    private readonly utilsService: UtilsService,
     private readonly emailService: EmailService,
   ) {}
 
@@ -64,18 +62,17 @@ export class AuthService {
       return {
         id: newUser.id,
         email: newUser.email,
-        nickname: newUser.nickname,
+        nickname: newUser.nickname ?? '',
         image: newUser.image,
-        createdAt: this.utilsService.dateToTimestamp(newUser.createdAt as Date),
-        updatedAt: this.utilsService.dateToTimestamp(newUser.updatedAt as Date),
-        deletedAt: newUser.deletedAt
-          ? this.utilsService.dateToTimestamp(newUser.deletedAt as Date)
-          : null,
+        createdAt: newUser.createdAt.toISOString(),
+        updatedAt: newUser.updatedAt.toISOString(),
+        deletedAt: newUser.deletedAt ? newUser.deletedAt.toISOString() : null,
         gender: newUser.gender,
       } as User;
     }
     return {
       ...user,
+      nickname: user.nickname ?? '',
       createdAt: user.createdAt.toISOString(),
       updatedAt: user.updatedAt.toISOString(),
       deletedAt: user.deletedAt ? user.deletedAt.toISOString() : null,


### PR DESCRIPTION
## Summary
Google OAuth 신규/초기 사용자가 AccessDenied로 막히는 백엔드 응답 정규화를 프로덕션에 배포합니다.

## 원인
- 운영 master의 OAuth 신규 사용자 생성 경로는 `nickname: null`과 protobuf Timestamp 날짜를 반환할 수 있었습니다.
- API Gateway `convertToUserEntity`는 `nickname`, `createdAt`, `updatedAt`을 문자열로 검증합니다.
- 이 검증 실패가 프론트 NextAuth에서는 `/api/auth/error?error=AccessDenied`로 노출됐습니다.

## 변경
- OAuth 응답의 `nickname`을 `null` 대신 빈 문자열로 정규화
- OAuth 신규 사용자 반환 날짜를 ISO 문자열로 통일
- 더 이상 사용하지 않는 `UtilsService` 주입 제거

## Test plan
- [x] `pnpm exec tsc -p apps/auth/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인: 173줄
- [ ] master 머지 후 GitHub Actions 배포 확인
- [ ] 배포 후 Google OAuth 재시도 확인

## Note
- develop 전체 release PR #75는 master와 충돌해 닫고, 장애 수정만 master 기준 hotfix로 분리했습니다.

🤖 Generated with [Codex](https://openai.com/codex)