### PR TITLE
🐛 OAuth 닉네임 응답 정규화

### DIFF
--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -65,7 +65,7 @@ export class AuthService {
       return {
         id: newUser.id,
         email: newUser.email,
-        nickname: newUser.nickname,
+        nickname: newUser.nickname ?? '',
         image: newUser.image,
         createdAt: newUser.createdAt.toISOString(),
         updatedAt: newUser.updatedAt.toISOString(),
@@ -75,6 +75,7 @@ export class AuthService {
     }
     return {
       ...user,
+      nickname: user.nickname ?? '',
       createdAt: user.createdAt.toISOString(),
       updatedAt: user.updatedAt.toISOString(),
       deletedAt: user.deletedAt ? user.deletedAt.toISOString() : null,


### PR DESCRIPTION
## Summary
운영 hotfix #76의 OAuth 닉네임 null 응답 정규화를 develop에도 반영합니다.

## 변경
- OAuth 신규/기존 사용자 응답의 `nickname`을 빈 문자열로 정규화
- 기존 DB에 `nickname: null`인 OAuth 사용자가 있어도 API Gateway 사용자 검증을 통과하도록 유지

## Test plan
- [x] `pnpm exec tsc -p apps/auth/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인: 192줄

🤖 Generated with [Codex](https://openai.com/codex)