### PR TITLE
🚀 Hotfix: RPC 예외 필터 fallback

### DIFF
--- a/libs/common/src/entity/rpc-exception.entity.ts
+++ b/libs/common/src/entity/rpc-exception.entity.ts
@@ -10,13 +10,28 @@ export function assertRpcExceptionData(data: any): RpcExceptionData {
   return data;
 }
 export function convertRpcException(error: any): RpcExceptionData {
+  if (!error || typeof error !== 'object') {
+    return {
+      code: 13,
+      message: 'Internal server error',
+    };
+  }
+
   return {
-    code: error.code,
-    message: error.message,
+    code: isRpcExceptionCode(error.code) ? error.code : 13,
+    message:
+      typeof error.message === 'string' ? error.message : 'Internal server error',
   };
 }
 export function isRpcExceptionData(data: any): data is RpcExceptionData {
-  return data.code !== undefined && data.message !== undefined;
+  return (
+    data &&
+    isRpcExceptionCode(data.code) &&
+    typeof data.message === 'string'
+  );
+}
+export function isRpcExceptionCode(code: any): code is RpcExceptionCode {
+  return Number.isInteger(code) && code >= 1 && code <= 16;
 }
 export function assertNever(x: never): never {
   throw new Error('Unexpected object: ' + x);

--- a/libs/common/src/filters/rpcexception/rpc-exception.filter.ts
+++ b/libs/common/src/filters/rpcexception/rpc-exception.filter.ts
@@ -16,7 +16,7 @@ export class RpcExceptionFilter implements ExceptionFilter {
     const rpcException = assertRpcExceptionData(errorData);
     const statusCode = mapRpcExceptionToStatusCode(rpcException.code);
     response.status(statusCode).json({
-      message: exception.message,
+      message: rpcException.message,
     });
   }
 }


### PR DESCRIPTION
## Summary
api-gateway가 malformed RpcException을 처리하다 프로세스가 종료되는 문제를 방지합니다.

## 원인
- `RpcExceptionFilter`가 예외 데이터를 검증하다 `Invalid RpcExceptionData`를 다시 throw했습니다.
- 이로 인해 원래 500 응답으로 끝나야 할 오류가 api-gateway 프로세스 종료로 커졌습니다.

## 변경
- RPC 예외 변환 시 code/message가 없거나 형식이 맞지 않으면 INTERNAL(13) + 기본 메시지로 fallback
- HTTP 응답 메시지는 정규화된 `rpcException.message`를 사용

## Test plan
- [x] `pnpm exec tsc -p apps/auth/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인
- [ ] `api-gateway` 타입체크는 기존 Prisma notification 타입 생성 누락으로 실패함
- [ ] master 머지 후 GitHub Actions 배포 확인

🤖 Generated with [Codex](https://openai.com/codex)