### PR TITLE
🐛 RPC 예외 필터 fallback 동기화

### DIFF
--- a/libs/common/src/entity/rpc-exception.entity.ts
+++ b/libs/common/src/entity/rpc-exception.entity.ts
@@ -10,13 +10,28 @@ export function assertRpcExceptionData(data: any): RpcExceptionData {
   return data;
 }
 export function convertRpcException(error: any): RpcExceptionData {
+  if (!error || typeof error !== 'object') {
+    return {
+      code: 13,
+      message: 'Internal server error',
+    };
+  }
+
   return {
-    code: error.code,
-    message: error.message,
+    code: isRpcExceptionCode(error.code) ? error.code : 13,
+    message:
+      typeof error.message === 'string' ? error.message : 'Internal server error',
   };
 }
 export function isRpcExceptionData(data: any): data is RpcExceptionData {
-  return data.code !== undefined && data.message !== undefined;
+  return (
+    data &&
+    isRpcExceptionCode(data.code) &&
+    typeof data.message === 'string'
+  );
+}
+export function isRpcExceptionCode(code: any): code is RpcExceptionCode {
+  return Number.isInteger(code) && code >= 1 && code <= 16;
 }
 export function assertNever(x: never): never {
   throw new Error('Unexpected object: ' + x);

--- a/libs/common/src/filters/rpcexception/rpc-exception.filter.ts
+++ b/libs/common/src/filters/rpcexception/rpc-exception.filter.ts
@@ -16,7 +16,7 @@ export class RpcExceptionFilter implements ExceptionFilter {
     const rpcException = assertRpcExceptionData(errorData);
     const statusCode = mapRpcExceptionToStatusCode(rpcException.code);
     response.status(statusCode).json({
-      message: exception.message,
+      message: rpcException.message,
     });
   }
 }


### PR DESCRIPTION
## Summary
운영 hotfix #78의 RPC 예외 필터 fallback을 develop에도 반영합니다.

## 변경
- malformed RpcException을 INTERNAL(13) + 기본 메시지로 정규화
- 응답 메시지로 정규화된 `rpcException.message` 사용

## Test plan
- [x] `pnpm exec tsc -p apps/auth/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Codex](https://openai.com/codex)