### PR TITLE
🚀 Hotfix: OAuth 사용자 gender 응답 정규화

### DIFF
--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -67,7 +67,7 @@ export class AuthService {
         createdAt: newUser.createdAt.toISOString(),
         updatedAt: newUser.updatedAt.toISOString(),
         deletedAt: newUser.deletedAt ? newUser.deletedAt.toISOString() : null,
-        gender: newUser.gender,
+        gender: newUser.gender ?? '',
       } as User;
     }
     return {
@@ -76,7 +76,7 @@ export class AuthService {
       createdAt: user.createdAt.toISOString(),
       updatedAt: user.updatedAt.toISOString(),
       deletedAt: user.deletedAt ? user.deletedAt.toISOString() : null,
-      gender: user.gender,
+      gender: user.gender ?? '',
     };
   }
 

--- a/libs/common/src/entity/users-entity.ts
+++ b/libs/common/src/entity/users-entity.ts
@@ -4,14 +4,14 @@ export function convertToUserEntity(arg: any) {
   const result = {
     id: arg.id,
     email: arg.email,
-    nickname: arg.nickname,
+    nickname: arg.nickname ?? '',
     image: arg.image
       ? (process.env.FILE_SERVER_API ?? '').replace(/\/$/, '') + arg.image
       : '',
     createdAt: arg.createdAt,
     updatedAt: arg.updatedAt,
     deletedAt: arg.deletedAt ?? null,
-    gender: arg.gender,
+    gender: arg.gender ?? '',
   };
   assertUserEntity(result);
   return result;


### PR DESCRIPTION
## Summary
Google OAuth 사용자의 `gender` null/undefined 응답이 API Gateway 사용자 검증을 실패시키는 문제를 수정합니다.

## 원인
- OAuth 사용자는 gender가 null일 수 있습니다.
- `user.proto`의 gender는 string이고, gRPC/API Gateway를 거치며 null이 undefined처럼 전달되면 `convertToUserEntity` 검증에서 실패할 수 있습니다.
- 이 실패가 프론트 NextAuth에서는 AccessDenied로 노출됩니다.

## 변경
- auth 서비스 OAuth 응답에서 `gender`를 빈 문자열로 정규화
- API Gateway 공통 사용자 변환에서 `nickname`, `gender` fallback을 빈 문자열로 보정

## Test plan
- [x] `pnpm exec tsc -p apps/auth/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인
- [ ] `api-gateway` 타입체크는 기존 Prisma notification 타입 생성 누락으로 실패함
- [ ] master 머지 후 GitHub Actions 배포 확인

🤖 Generated with [Codex](https://openai.com/codex)