### PR TITLE
🐛 OAuth gender 응답 정규화 동기화

### DIFF
--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -70,7 +70,7 @@ export class AuthService {
         createdAt: newUser.createdAt.toISOString(),
         updatedAt: newUser.updatedAt.toISOString(),
         deletedAt: newUser.deletedAt ? newUser.deletedAt.toISOString() : null,
-        gender: newUser.gender,
+        gender: newUser.gender ?? '',
       } as User;
     }
     return {
@@ -79,7 +79,7 @@ export class AuthService {
       createdAt: user.createdAt.toISOString(),
       updatedAt: user.updatedAt.toISOString(),
       deletedAt: user.deletedAt ? user.deletedAt.toISOString() : null,
-      gender: user.gender,
+      gender: user.gender ?? '',
     };
   }
 

--- a/libs/common/src/entity/users-entity.ts
+++ b/libs/common/src/entity/users-entity.ts
@@ -4,14 +4,14 @@ export function convertToUserEntity(arg: any) {
   const result = {
     id: arg.id,
     email: arg.email,
-    nickname: arg.nickname,
+    nickname: arg.nickname ?? '',
     image: arg.image
       ? (process.env.FILE_SERVER_API ?? '').replace(/\/$/, '') + arg.image
       : '',
     createdAt: arg.createdAt,
     updatedAt: arg.updatedAt,
     deletedAt: arg.deletedAt ?? null,
-    gender: arg.gender,
+    gender: arg.gender ?? '',
   };
   assertUserEntity(result);
   return result;


### PR DESCRIPTION
## Summary
운영 hotfix #80의 OAuth gender 응답 정규화를 develop에도 반영합니다.

## 변경
- auth 서비스 OAuth 응답에서 `gender`를 빈 문자열로 정규화
- API Gateway 공통 사용자 변환에서 `nickname`, `gender` fallback 보정

## Test plan
- [x] `pnpm exec tsc -p apps/auth/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인: auth 192줄, users-entity 36줄

🤖 Generated with [Codex](https://openai.com/codex)