### PR TITLE
✨ 채팅방 목록 메타 응답 추가

### DIFF
--- a/apps/chat/src/chat-room.service.ts
+++ b/apps/chat/src/chat-room.service.ts
@@ -20,7 +20,24 @@ export class ChatRoomService {
   private readonly logger = new Logger(ChatRoomService.name);
   constructor(private readonly prisma: MySQLPrismaService) {}
 
+  private readonly roomInclude = {
+    ChatRoomMember: {
+      where: { leftAt: null },
+      include: {
+        User: {
+          select: { id: true, nickname: true, image: true },
+        },
+      },
+    },
+    ChatMessage: {
+      orderBy: { createdAt: 'desc' as const },
+      take: 1,
+    },
+  };
+
   private formatRoom(room: any): ChatRoom {
+    const lastMessage = room.ChatMessage?.[0];
+
     return {
       id: room.id,
       name: room.name,
@@ -29,6 +46,13 @@ export class ChatRoomService {
       createdAt: room.createdAt.toISOString(),
       updatedAt: room.updatedAt.toISOString(),
       matchPostId: room.matchPostId ?? '',
+      memberProfiles: room.ChatRoomMember.map((member: any) => ({
+        userId: member.userId,
+        nickname: member.User?.nickname ?? '',
+        image: member.User?.image ?? '',
+      })),
+      lastMessage: lastMessage?.content ?? '',
+      lastMessageAt: lastMessage?.createdAt?.toISOString() ?? '',
     };
   }
 
@@ -52,7 +76,7 @@ export class ChatRoomService {
             every: { userId: { in: memberIds }, leftAt: null },
           },
         },
-        include: { ChatRoomMember: { where: { leftAt: null } } },
+        include: this.roomInclude,
       });
 
       if (existingRoom && existingRoom.ChatRoomMember.length === 2) {
@@ -61,7 +85,7 @@ export class ChatRoomService {
           const updated = await this.prisma.chatRoom.update({
             where: { id: existingRoom.id },
             data: { matchPostId },
-            include: { ChatRoomMember: { where: { leftAt: null } } },
+            include: this.roomInclude,
           });
           return { chatRoom: this.formatRoom(updated) };
         }
@@ -78,7 +102,7 @@ export class ChatRoomService {
           create: memberIds.map((userId) => ({ userId })),
         },
       },
-      include: { ChatRoomMember: { where: { leftAt: null } } },
+      include: this.roomInclude,
     });
 
     return { chatRoom: this.formatRoom(chatRoom) };
@@ -91,7 +115,7 @@ export class ChatRoomService {
         id: chatRoomId,
         ChatRoomMember: { some: { userId, leftAt: null } },
       },
-      include: { ChatRoomMember: { where: { leftAt: null } } },
+      include: this.roomInclude,
     });
 
     if (!chatRoom) {
@@ -113,10 +137,7 @@ export class ChatRoomService {
       where: {
         ChatRoomMember: { some: { userId, leftAt: null } },
       },
-      include: {
-        ChatRoomMember: { where: { leftAt: null } },
-        ChatMessage: { orderBy: { createdAt: 'desc' }, take: 1 },
-      },
+      include: this.roomInclude,
       orderBy: { updatedAt: 'desc' },
       skip,
       take: pageSize + 1,

--- a/libs/common/src/protobuf/chat.ts
+++ b/libs/common/src/protobuf/chat.ts
@@ -5,6 +5,12 @@ import { Observable } from 'rxjs';
 export const chatProtobufPackage = 'chat';
 
 /** Chat Room Messages */
+export interface ChatRoomMemberProfile {
+  userId: number;
+  nickname: string;
+  image: string;
+}
+
 export interface ChatRoom {
   id: string;
   name: string;
@@ -15,6 +21,9 @@ export interface ChatRoom {
   updatedAt: string;
   /** 채팅방을 생성한 매칭 게시글 ID */
   matchPostId?: string;
+  memberProfiles: ChatRoomMemberProfile[];
+  lastMessage: string;
+  lastMessageAt: string;
 }
 
 export interface ChatMessage {

--- a/proto/chat.proto
+++ b/proto/chat.proto
@@ -3,6 +3,12 @@ syntax = "proto3";
 package chat;
 
 // Chat Room Messages
+message ChatRoomMemberProfile {
+  int32 userId = 1;
+  string nickname = 2;
+  string image = 3;
+}
+
 message ChatRoom {
   string id = 1;
   string name = 2;
@@ -11,6 +17,9 @@ message ChatRoom {
   string createdAt = 5;
   string updatedAt = 6;
   string matchPostId = 7; // 채팅방을 생성한 매칭 게시글 ID (없으면 빈 문자열)
+  repeated ChatRoomMemberProfile memberProfiles = 8;
+  string lastMessage = 9;
+  string lastMessageAt = 10;
 }
 
 message ChatMessage {


### PR DESCRIPTION
## Summary
채팅방 목록 응답에 상대 프로필과 마지막 메시지 정보를 포함합니다.

## 원인
프론트 채팅 목록에서 상대 프로필 이미지와 마지막 메시지 시간을 표시할 수 있는 메타 데이터가 없었습니다.

## 변경
- ChatRoom proto에 memberProfiles, lastMessage, lastMessageAt 추가
- chat-service 조회 응답에 멤버 닉네임/이미지와 최근 메시지 정보 포함
- 생성/단건/목록 조회에서 동일한 채팅방 메타 응답 사용

## Test plan
- [x] pnpm prisma generate --schema=prisma/mysql.schema.prisma
- [x] pnpm exec tsc -p apps/chat/tsconfig.app.json --noEmit --incremental false
- [x] 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)