### PR TITLE
✨ 공개 채팅 웹소켓 추가

### DIFF
--- a/apps/chat/src/chat.gateway.ts
+++ b/apps/chat/src/chat.gateway.ts
@@ -13,6 +13,13 @@ import { Server, Socket } from 'socket.io';
 import { onlineMap } from './online.map';
 import { MySQLPrismaService } from '@app/prisma';
 
+interface PublicChatPayload {
+  clientId?: string;
+  nickName?: string;
+  message?: string;
+  createdAt?: string;
+}
+
 @WebSocketGateway({ namespace: /\/ws-.+/, cors: { origin: '*' } })
 export class ChatGateway
   implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
@@ -27,6 +34,22 @@ export class ChatGateway
     return 'pong';
   }
 
+  @SubscribeMessage('message')
+  handlePublicMessage(
+    @MessageBody() data: PublicChatPayload,
+    @ConnectedSocket() socket: Socket,
+  ) {
+    const message = data.message?.trim().slice(0, 500);
+    if (!message) return;
+
+    socket.nsp.emit('message', {
+      clientId: data.clientId,
+      nickName: data.nickName?.trim().slice(0, 24) || '익명',
+      message,
+      createdAt: data.createdAt || new Date().toISOString(),
+    });
+  }
+
   @SubscribeMessage('sendMessage')
   async handleSendMessage(
     @MessageBody()
@@ -38,7 +61,9 @@ export class ChatGateway
     },
     @ConnectedSocket() socket: Socket,
   ) {
-    this.logger.debug(`handleSendMessage ns=${socket.nsp.name} room=${data.chatRoomId}`);
+    this.logger.debug(
+      `handleSendMessage ns=${socket.nsp.name} room=${data.chatRoomId}`,
+    );
     try {
       // 새로운 Chat 시스템을 사용하여 메시지 저장
       const message = await this.prisma.chatMessage.create({
@@ -75,7 +100,9 @@ export class ChatGateway
     @MessageBody() data: { userId: number; chatRoomId: string },
     @ConnectedSocket() socket: Socket,
   ) {
-    this.logger.debug(`handleJoinRoom userId=${data.userId} room=${data.chatRoomId} ns=${socket.nsp.name}`);
+    this.logger.debug(
+      `handleJoinRoom userId=${data.userId} room=${data.chatRoomId} ns=${socket.nsp.name}`,
+    );
 
     // 온라인 맵에 사용자 추가
     if (!onlineMap[socket.nsp.name]) {


### PR DESCRIPTION
## Summary
공개 채팅 화면에서 사용할 WebSocket message 이벤트를 추가했습니다.
기존 매칭 채팅 저장/방 참여 흐름과 분리해 공개 메시지만 브로드캐스트합니다.

## 원인
프론트에 공개 채팅 화면을 추가해도 서버가 일반 message 이벤트를 처리하지 않아 사용자 간 실시간 대화가 전달되지 않았습니다.

## 변경
- ws-public 등 ws-* 네임스페이스에서 message 이벤트 수신
- 닉네임 24자, 메시지 500자 제한 후 네임스페이스 전체에 브로드캐스트
- 기존 sendMessage DB 저장 흐름은 유지

## Test plan
- [x] pnpm prisma generate --schema=prisma/mysql.schema.prisma
- [x] pnpm exec tsc -p apps/chat/tsconfig.app.json --noEmit --incremental false
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)