### PR TITLE
🐛 공개 채팅 메시지 저장 추가

### DIFF
--- a/apps/chat/src/chat.gateway.ts
+++ b/apps/chat/src/chat.gateway.ts
@@ -20,6 +20,14 @@ interface PublicChatPayload {
   createdAt?: string;
 }
 
+interface PublicChatMessageView {
+  id: string;
+  clientId?: string;
+  nickName: string;
+  message: string;
+  createdAt: string;
+}
+
 @WebSocketGateway({ namespace: /\/ws-.+/, cors: { origin: '*' } })
 export class ChatGateway
   implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
@@ -35,19 +43,29 @@ export class ChatGateway
   }
 
   @SubscribeMessage('message')
-  handlePublicMessage(
+  async handlePublicMessage(
     @MessageBody() data: PublicChatPayload,
     @ConnectedSocket() socket: Socket,
   ) {
+    if (socket.nsp.name !== '/ws-public') return;
+
     const message = data.message?.trim().slice(0, 500);
     if (!message) return;
 
-    socket.nsp.emit('message', {
-      clientId: data.clientId,
-      nickName: data.nickName?.trim().slice(0, 24) || '익명',
-      message,
-      createdAt: data.createdAt || new Date().toISOString(),
-    });
+    try {
+      const savedMessage = await this.prisma.publicChatMessage.create({
+        data: {
+          clientId: data.clientId || null,
+          nickName: data.nickName?.trim().slice(0, 24) || '익명',
+          content: message,
+        },
+      });
+
+      socket.nsp.emit('message', this.toPublicChatView(savedMessage));
+    } catch (error) {
+      this.logger.error('Error handling public message', error?.stack ?? error);
+      socket.emit('error', { message: 'Failed to send public message' });
+    }
   }
 
   @SubscribeMessage('sendMessage')
@@ -123,12 +141,15 @@ export class ChatGateway
     this.logger.log('ChatGateway initialized');
   }
 
-  handleConnection(@ConnectedSocket() socket: Socket) {
+  async handleConnection(@ConnectedSocket() socket: Socket) {
     this.logger.verbose(`connected ${socket.nsp.name}`);
     if (!onlineMap[socket.nsp.name]) {
       onlineMap[socket.nsp.name] = {};
     }
     socket.emit('hello', socket.nsp.name);
+    if (socket.nsp.name === '/ws-public') {
+      await this.sendPublicHistory(socket);
+    }
   }
 
   handleDisconnect(@ConnectedSocket() socket: Socket) {
@@ -141,5 +162,34 @@ export class ChatGateway
         Object.values(onlineMap[socket.nsp.name]),
       );
     }
+  }
+
+  private async sendPublicHistory(socket: Socket) {
+    const messages = await this.prisma.publicChatMessage.findMany({
+      where: { deletedAt: null },
+      orderBy: { createdAt: 'desc' },
+      take: 80,
+    });
+
+    socket.emit(
+      'history',
+      messages.reverse().map((message) => this.toPublicChatView(message)),
+    );
+  }
+
+  private toPublicChatView(message: {
+    id: string;
+    clientId: string | null;
+    nickName: string;
+    content: string;
+    createdAt: Date;
+  }): PublicChatMessageView {
+    return {
+      id: message.id,
+      clientId: message.clientId || undefined,
+      nickName: message.nickName,
+      message: message.content,
+      createdAt: message.createdAt.toISOString(),
+    };
   }
 }

--- a/prisma/migrations/20260614000000_add_public_chat_messages/migration.sql
+++ b/prisma/migrations/20260614000000_add_public_chat_messages/migration.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `public_chat_messages` (
+    `id` VARCHAR(191) NOT NULL,
+    `clientId` VARCHAR(191) NULL,
+    `nickName` VARCHAR(24) NOT NULL,
+    `content` VARCHAR(500) NOT NULL,
+    `createdAt` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    `deletedAt` DATETIME(6) NULL,
+
+    INDEX `PublicChatMessage_createdAt_idx`(`createdAt`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -234,6 +234,18 @@ model ChatMessage {
   @@map("chat_messages")
 }
 
+model PublicChatMessage {
+  id        String    @id @default(cuid())
+  clientId  String?   @db.VarChar(191)
+  nickName  String    @db.VarChar(24)
+  content   String    @db.VarChar(500)
+  createdAt DateTime  @default(now()) @db.DateTime(6)
+  deletedAt DateTime? @db.DateTime(6)
+
+  @@index([createdAt], map: "PublicChatMessage_createdAt_idx")
+  @@map("public_chat_messages")
+}
+
 
 enum articleLikes_type {
   like


### PR DESCRIPTION
## Summary
공개 채팅 메시지를 DB에 저장하고, 접속 시 최근 메시지 80개를 내려주도록 수정했습니다.

## 원인
기존 공개 채팅은 WebSocket 브로드캐스트만 수행해 새로고침하면 메시지가 사라졌습니다. 기존 ChatMessage는 senderId가 필수라 비로그인 공개 채팅 저장에 맞지 않았습니다.

## 변경
- public_chat_messages 테이블 마이그레이션 추가
- PublicChatMessage Prisma 모델 추가
- /ws-public message 이벤트에서 메시지 저장 후 브로드캐스트
- /ws-public 접속 시 history 이벤트로 최근 메시지 80개 전송

## Test plan
- [x] pnpm prisma generate --schema=prisma/mysql.schema.prisma
- [x] pnpm exec tsc -p apps/chat/tsconfig.app.json --noEmit --incremental false
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)