### PR TITLE
🐛 영화 장르와 관람등급을 KOFIC 상세로 보강

### DIFF
--- a/apps/movie/src/movie-metadata.client.ts
+++ b/apps/movie/src/movie-metadata.client.ts
@@ -9,6 +9,12 @@ import { Logger } from '@nestjs/common';
 import axios from 'axios';
 import moment from 'moment';
 
+interface KoficMovieMetadata {
+  director: string;
+  genre: string;
+  rating: string;
+}
+
 export class MovieMetadataClient {
   private readonly logger = new Logger(MovieMetadataClient.name);
   private readonly koficKey = process.env.KOFIC_API_KEY;
@@ -27,19 +33,19 @@ export class MovieMetadataClient {
     return response.data?.boxOfficeResult?.dailyBoxOfficeList ?? null;
   }
 
-  async fetchKoficDirector(movieCd: string): Promise<string> {
+  async fetchKoficMetadata(movieCd: string): Promise<KoficMovieMetadata> {
     try {
       const url = `${this.koficMovieDetailUrl}?key=${this.koficKey}&movieCd=${movieCd}`;
       const response = await axios.get<KobisMovieDetailResponse>(url);
-      return (
-        response.data?.movieInfoResult?.movieInfo?.directors
-          ?.map((director) => director.peopleNm?.trim())
-          ?.filter(Boolean)
-          ?.join(', ') ?? ''
-      );
+      const movieInfo = response.data?.movieInfoResult?.movieInfo;
+      return {
+        director: this.joinNames(movieInfo?.directors, 'peopleNm'),
+        genre: this.joinNames(movieInfo?.genres, 'genreNm'),
+        rating: this.joinNames(movieInfo?.audits, 'watchGradeNm'),
+      };
     } catch (error) {
-      this.logger.warn(`fetchKoficDirector failed for "${movieCd}": ${error}`);
-      return '';
+      this.logger.warn(`fetchKoficMetadata failed for "${movieCd}": ${error}`);
+      return { director: '', genre: '', rating: '' };
     }
   }
 
@@ -108,5 +114,17 @@ export class MovieMetadataClient {
   private getHighResKmdbPoster(posters: string): string {
     const urls = posters?.split('|') ?? [];
     return urls.find((url) => url.includes('/MD/')) || urls[0] || '';
+  }
+
+  private joinNames<T extends Record<string, string>>(
+    items: T[] | undefined,
+    key: keyof T,
+  ): string {
+    return (
+      items
+        ?.map((item) => item[key]?.trim())
+        ?.filter(Boolean)
+        ?.join(', ') ?? ''
+    );
   }
 }

--- a/apps/movie/src/movie-sync.service.ts
+++ b/apps/movie/src/movie-sync.service.ts
@@ -97,14 +97,23 @@ export class MovieSyncService implements OnModuleInit {
     const movieCds = movieList.map((movie) => +movie.movieCd);
     const existingMovies = await this.prisma.movie.findMany({
       where: { movieCd: { in: movieCds } },
-      select: { movieCd: true, updatedAt: true, director: true },
+      select: {
+        movieCd: true,
+        updatedAt: true,
+        director: true,
+        genre: true,
+        ratting: true,
+      },
     });
 
     if (existingMovies.length !== movieList.length) return false;
 
     return existingMovies.every(
       (movie) =>
-        movie.updatedAt >= dateObject && Boolean(movie.director?.trim()),
+        movie.updatedAt >= dateObject &&
+        Boolean(movie.director?.trim()) &&
+        Boolean(movie.genre?.trim()) &&
+        Boolean(movie.ratting?.trim()),
     );
   }
 
@@ -126,10 +135,12 @@ export class MovieSyncService implements OnModuleInit {
         rating = fetchedData.rating ?? '';
       }
 
-      const koficDirector = await this.metadataClient.fetchKoficDirector(
+      const koficMetadata = await this.metadataClient.fetchKoficMetadata(
         movieData.movieCd,
       );
-      if (koficDirector) director = koficDirector;
+      if (koficMetadata.director) director = koficMetadata.director;
+      if (koficMetadata.genre) genre = koficMetadata.genre;
+      if (koficMetadata.rating) rating = koficMetadata.rating;
 
       const tmdbData = await this.metadataClient.fetchTmdbData(
         movieData.movieNm,

--- a/libs/common/src/types/movie-response.ts
+++ b/libs/common/src/types/movie-response.ts
@@ -154,6 +154,13 @@ export interface KobisMovieDetailResponse {
       directors: {
         peopleNm: string;
       }[];
+      genres: {
+        genreNm: string;
+      }[];
+      audits: {
+        auditNo: string;
+        watchGradeNm: string;
+      }[];
     };
   };
 }


### PR DESCRIPTION
## Summary
- KOFIC 영화 상세 조회를 감독 전용에서 감독/장르/관람등급 메타 조회로 확장
- 오늘 박스오피스 캐시 freshness 조건에 장르와 관람등급 누락 여부를 포함
- KMDB 값이 비어 있어도 KOFIC movieCd 기준 상세 값으로 장르/심의등급을 보강

## Test plan
- [x] `/Users/gimsihun/Documents/drunkenmovie/nest-msa/node_modules/.bin/prettier --write apps/movie/src/movie-metadata.client.ts apps/movie/src/movie-sync.service.ts libs/common/src/types/movie-response.ts`
- [x] `pnpm exec tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인 (`movie-metadata.client.ts` 130줄, `movie-sync.service.ts` 189줄, `movie-response.ts` 166줄)

🤖 Generated with Codex