### PR TITLE
✨ 영화 포스터 S3 저장 추가

### DIFF
--- a/apps/movie/src/movie-poster-storage.service.ts
+++ b/apps/movie/src/movie-poster-storage.service.ts
@@ -1,0 +1,91 @@
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
+import path from 'path';
+
+@Injectable()
+export class MoviePosterStorageService {
+  private readonly logger = new Logger(MoviePosterStorageService.name);
+  private readonly storageDriver = process.env.FILE_STORAGE_DRIVER ?? 'local';
+  private readonly s3Bucket = process.env.AWS_S3_BUCKET;
+  private readonly s3Region = process.env.AWS_REGION ?? 'ap-northeast-2';
+  private readonly s3PublicUrl = process.env.AWS_S3_PUBLIC_URL;
+  private readonly s3Client = new S3Client({ region: this.s3Region });
+
+  async mirrorPoster(posterUrl: string, movieCd: number): Promise<string> {
+    if (!posterUrl || !this.isS3Enabled() || this.isStoredPoster(posterUrl)) {
+      return posterUrl;
+    }
+
+    try {
+      const response = await axios.get<ArrayBuffer>(posterUrl, {
+        responseType: 'arraybuffer',
+        timeout: 10000,
+      });
+      const contentType = this.getContentType(response.headers['content-type']);
+      const key = `posters/${movieCd}${this.getExtension(
+        posterUrl,
+        contentType,
+      )}`;
+
+      await this.s3Client.send(
+        new PutObjectCommand({
+          Bucket: this.s3Bucket,
+          Key: key,
+          Body: Buffer.from(response.data),
+          ContentType: contentType,
+        }),
+      );
+
+      return `${this.getPublicBaseUrl()}/${key}`;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to mirror poster for movieCd=${movieCd}: ${error}`,
+      );
+      return posterUrl;
+    }
+  }
+
+  isReadyPoster(posterUrl?: string | null): boolean {
+    if (!this.isS3Enabled()) return true;
+    return Boolean(posterUrl && this.isStoredPoster(posterUrl));
+  }
+
+  private isS3Enabled(): boolean {
+    return this.storageDriver === 's3' && Boolean(this.s3Bucket);
+  }
+
+  private isStoredPoster(posterUrl: string): boolean {
+    const publicBaseUrl = this.getPublicBaseUrl();
+    const bucketBaseUrl = `https://${this.s3Bucket}.s3.${this.s3Region}.amazonaws.com`;
+    return (
+      posterUrl.startsWith(`${publicBaseUrl}/posters/`) ||
+      posterUrl.startsWith(`${bucketBaseUrl}/posters/`)
+    );
+  }
+
+  private getPublicBaseUrl(): string {
+    return (
+      this.s3PublicUrl?.replace(/\/$/, '') ??
+      `https://${this.s3Bucket}.s3.${this.s3Region}.amazonaws.com`
+    );
+  }
+
+  private getContentType(value: unknown): string {
+    const contentType = Array.isArray(value) ? value[0] : value;
+    return typeof contentType === 'string' && contentType.startsWith('image/')
+      ? contentType.split(';')[0]
+      : 'image/jpeg';
+  }
+
+  private getExtension(posterUrl: string, contentType: string): string {
+    const extension = path.extname(new URL(posterUrl).pathname).toLowerCase();
+    if (['.jpg', '.jpeg', '.png', '.webp'].includes(extension)) {
+      return extension;
+    }
+
+    if (contentType === 'image/png') return '.png';
+    if (contentType === 'image/webp') return '.webp';
+    return '.jpg';
+  }
+}

--- a/apps/movie/src/movie-sync.service.ts
+++ b/apps/movie/src/movie-sync.service.ts
@@ -9,13 +9,17 @@ import {
 import moment from 'moment';
 import { convertKobisMovieData } from './movie.formatter';
 import { MovieMetadataClient } from './movie-metadata.client';
+import { MoviePosterStorageService } from './movie-poster-storage.service';
 
 @Injectable()
 export class MovieSyncService implements OnModuleInit {
   private readonly logger = new Logger(MovieSyncService.name);
   private readonly metadataClient = new MovieMetadataClient();
 
-  constructor(private readonly prisma: MySQLPrismaService) {}
+  constructor(
+    private readonly prisma: MySQLPrismaService,
+    private readonly posterStorage: MoviePosterStorageService,
+  ) {}
 
   onModuleInit() {
     this.fetchMovies();
@@ -50,6 +54,10 @@ export class MovieSyncService implements OnModuleInit {
       try {
         const { plot, poster, director, genre, rating, fetchedData } =
           await this.fetchExternalMetadata(movieData);
+        const storedPoster = await this.posterStorage.mirrorPoster(
+          poster,
+          +movieData.movieCd,
+        );
 
         await this.prisma.movie.upsert({
           where: { movieCd: +movieData.movieCd },
@@ -59,7 +67,7 @@ export class MovieSyncService implements OnModuleInit {
             updatedAt: new Date(),
             rankInten: movieData.rankInten,
             rankOldAndNew: movieData.rankOldAndNew,
-            ...(poster && { poster }),
+            ...(storedPoster && { poster: storedPoster }),
             ...(plot && { plot }),
             ...(director && { director }),
             ...(genre && { genre }),
@@ -71,7 +79,7 @@ export class MovieSyncService implements OnModuleInit {
             audience: +movieData.audiAcc,
             rank: +movieData.rank,
             vector: [],
-            poster,
+            poster: storedPoster,
             rankInten: movieData.rankInten,
             rankOldAndNew: movieData.rankOldAndNew,
             openDt: new Date(movieData.openDt),
@@ -103,6 +111,7 @@ export class MovieSyncService implements OnModuleInit {
         director: true,
         genre: true,
         ratting: true,
+        poster: true,
       },
     });
 
@@ -113,7 +122,8 @@ export class MovieSyncService implements OnModuleInit {
         movie.updatedAt >= dateObject &&
         Boolean(movie.director?.trim()) &&
         Boolean(movie.genre?.trim()) &&
-        Boolean(movie.ratting?.trim()),
+        Boolean(movie.ratting?.trim()) &&
+        this.posterStorage.isReadyPoster(movie.poster),
     );
   }
 

--- a/apps/movie/src/movie.module.ts
+++ b/apps/movie/src/movie.module.ts
@@ -4,12 +4,19 @@ import { MovieService } from './movie.service';
 import { MovieSyncService } from './movie-sync.service';
 import { MovieReadService } from './movie-read.service';
 import { MovieScoreService } from './movie-score.service';
+import { MoviePosterStorageService } from './movie-poster-storage.service';
 import { PrismaModule } from '@app/prisma';
 import { UtilsModule } from '@app/utils';
 
 @Module({
   imports: [PrismaModule, UtilsModule],
   controllers: [MovieController],
-  providers: [MovieService, MovieSyncService, MovieReadService, MovieScoreService],
+  providers: [
+    MovieService,
+    MovieSyncService,
+    MovieReadService,
+    MovieScoreService,
+    MoviePosterStorageService,
+  ],
 })
 export class MovieModule {}


### PR DESCRIPTION
## Summary
영화 동기화 시 외부 포스터 이미지를 S3 `posters/` prefix로 미러링하고, Movie.poster에는 S3 URL을 저장합니다.

## 변경
- 영화 포스터 S3 미러링 서비스 추가
- 영화 동기화 upsert 시 외부 poster URL 대신 S3 URL 저장
- 이미 동기화된 영화라도 poster가 S3 URL이 아니면 fresh 판정을 통과하지 않게 수정

## Test plan
- [x] `node node_modules/typescript/bin/tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인

## 운영 확인
- S3/IAM 정책에 `posters/*` PutObject/GetObject 권한과 public read bucket policy가 필요합니다.

🤖 Generated with Codex