### PR TITLE
🐛 회원탈퇴 soft delete 처리

### DIFF
--- a/apps/api-gateway/src/user/user.controller.ts
+++ b/apps/api-gateway/src/user/user.controller.ts
@@ -99,7 +99,7 @@ export class UserController {
   @Delete('/')
   @UseGuards(JwtAuthGuard, RateLimitGuard)
   remove(@Req() req) {
-    const userNumber = req.user.id;
+    const userNumber = req.user.userId;
     return this.userService.remove({ id: userNumber });
   }
 }

--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -23,8 +23,8 @@ export class AuthService {
   async validateUser(email: string, password: string) {
     if (!email || !password)
       throw new OutOfRangeException('아이디와 비밀번호를 확인해주세요.');
-    const user = await this.mysqlPrismaService.user.findUnique({
-      where: { email },
+    const user = await this.mysqlPrismaService.user.findFirst({
+      where: { email, deletedAt: null },
     });
     if (!user) return null;
 
@@ -47,7 +47,7 @@ export class AuthService {
 
   async oauthLogin({ providerId, provider }: { providerId: string; provider: string }) {
     const user = await this.mysqlPrismaService.user.findFirst({
-      where: { email: providerId },
+      where: { email: providerId, deletedAt: null },
     });
     if (!user) {
       const hashedPassword = await hash(randomBytes(32).toString('hex'), 10);

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -66,11 +66,12 @@ export class UserService {
     const userData = await this.mysqlPrismaService.user.findUnique({
       where: { id },
     });
-    if (!userData) {
+    if (!userData || userData.deletedAt) {
       throw new NotFoundException(`User not found ${id} `);
     }
-    const deletedUser = await this.mysqlPrismaService.user.delete({
+    const deletedUser = await this.mysqlPrismaService.user.update({
       where: { id },
+      data: { deletedAt: new Date() },
     });
     const createdAt = this.utilsService.dateToTimestamp(
       deletedUser.createdAt as Date,
@@ -78,9 +79,9 @@ export class UserService {
     const updatedAt = this.utilsService.dateToTimestamp(
       deletedUser.updatedAt as Date,
     );
-    const deletedAt = deletedUser.deletedAt
-      ? this.utilsService.dateToTimestamp(deletedUser.deletedAt as Date)
-      : null;
+    const deletedAt = this.utilsService.dateToTimestamp(
+      deletedUser.deletedAt as Date,
+    );
 
     const userObject: User = {
       id: deletedUser.id,


### PR DESCRIPTION
## Summary
회원탈퇴 API가 실제 row를 삭제하지 않고 `User.deletedAt`을 채우도록 변경합니다.

## 원인
기존 `DELETE /user`는 user-service에서 Prisma `delete()`를 호출해 hard delete가 발생했고, API Gateway에서는 JWT payload의 `userId`가 아닌 `id`를 참조하고 있었습니다.

## 변경
- `removeUser`를 hard delete에서 `deletedAt = now()` 업데이트로 변경
- API Gateway 회원탈퇴 요청 사용자 id를 `req.user.userId`로 수정
- 탈퇴 계정은 credentials/OAuth 로그인 조회 대상에서 제외

## Test plan
- [x] `node node_modules/.pnpm/typescript@5.1.3/node_modules/typescript/bin/tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] `node node_modules/.pnpm/typescript@5.1.3/node_modules/typescript/bin/tsc -p apps/user/tsconfig.app.json --noEmit --incremental false`
- [x] `node node_modules/.pnpm/typescript@5.1.3/node_modules/typescript/bin/tsc -p apps/auth/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)