### PR TITLE
✨ 공개채팅 프로필 메타데이터 추가

### DIFF
--- a/apps/chat/src/chat.gateway.ts
+++ b/apps/chat/src/chat.gateway.ts
@@ -12,28 +12,17 @@ import { Logger } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
 import { onlineMap } from './online.map';
 import { MySQLPrismaService } from '@app/prisma';
-
-interface PublicChatPayload {
-  clientId?: string;
-  nickName?: string;
-  message?: string;
-  createdAt?: string;
-}
-
-interface PublicChatMessageView {
-  id: string;
-  clientId?: string;
-  nickName: string;
-  message: string;
-  createdAt: string;
-}
+import { PublicChatPayload, PublicChatService } from './public-chat.service';
 
 @WebSocketGateway({ namespace: /\/ws-.+/, cors: { origin: '*' } })
 export class ChatGateway
   implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
 {
   private readonly logger = new Logger(ChatGateway.name);
-  constructor(private readonly prisma: MySQLPrismaService) {}
+  constructor(
+    private readonly prisma: MySQLPrismaService,
+    private readonly publicChatService: PublicChatService,
+  ) {}
   @WebSocketServer() public server: Server;
 
   @SubscribeMessage('health')
@@ -49,19 +38,9 @@ export class ChatGateway
   ) {
     if (socket.nsp.name !== '/ws-public') return;
 
-    const message = data.message?.trim().slice(0, 500);
-    if (!message) return;
-
     try {
-      const savedMessage = await this.prisma.publicChatMessage.create({
-        data: {
-          clientId: data.clientId || null,
-          nickName: data.nickName?.trim().slice(0, 24) || '익명',
-          content: message,
-        },
-      });
-
-      socket.nsp.emit('message', this.toPublicChatView(savedMessage));
+      const message = await this.publicChatService.createMessage(data);
+      if (message) socket.nsp.emit('message', message);
     } catch (error) {
       this.logger.error('Error handling public message', error?.stack ?? error);
       socket.emit('error', { message: 'Failed to send public message' });
@@ -148,6 +127,8 @@ export class ChatGateway
     }
     socket.emit('hello', socket.nsp.name);
     if (socket.nsp.name === '/ws-public') {
+      onlineMap[socket.nsp.name][socket.id] = socket.id;
+      this.emitPublicOnlineCount(socket);
       await this.sendPublicHistory(socket);
     }
   }
@@ -157,39 +138,26 @@ export class ChatGateway
     const newNamespace = socket.nsp;
     if (onlineMap[socket.nsp.name]) {
       delete onlineMap[socket.nsp.name][socket.id];
-      newNamespace.emit(
-        'onlineList',
-        Object.values(onlineMap[socket.nsp.name]),
-      );
+      if (socket.nsp.name === '/ws-public') {
+        this.emitPublicOnlineCount(socket);
+      } else {
+        newNamespace.emit(
+          'onlineList',
+          Object.values(onlineMap[socket.nsp.name]),
+        );
+      }
     }
   }
 
   private async sendPublicHistory(socket: Socket) {
-    const messages = await this.prisma.publicChatMessage.findMany({
-      where: { deletedAt: null },
-      orderBy: { createdAt: 'desc' },
-      take: 80,
-    });
+    socket.emit('history', await this.publicChatService.getHistory());
+  }
 
-    socket.emit(
-      'history',
-      messages.reverse().map((message) => this.toPublicChatView(message)),
+  private emitPublicOnlineCount(socket: Socket) {
+    socket.nsp.emit(
+      'onlineCount',
+      Object.keys(onlineMap[socket.nsp.name] ?? {}).length,
     );
   }
 
-  private toPublicChatView(message: {
-    id: string;
-    clientId: string | null;
-    nickName: string;
-    content: string;
-    createdAt: Date;
-  }): PublicChatMessageView {
-    return {
-      id: message.id,
-      clientId: message.clientId || undefined,
-      nickName: message.nickName,
-      message: message.content,
-      createdAt: message.createdAt.toISOString(),
-    };
-  }
 }

--- a/apps/chat/src/chat.module.ts
+++ b/apps/chat/src/chat.module.ts
@@ -4,11 +4,18 @@ import { ChatService } from './chat.service';
 import { ChatRoomService } from './chat-room.service';
 import { ChatMessageService } from './chat-message.service';
 import { ChatGateway } from './chat.gateway';
+import { PublicChatService } from './public-chat.service';
 import { PrismaModule } from '@app/prisma';
 
 @Module({
   imports: [PrismaModule],
   controllers: [ChatController],
-  providers: [ChatService, ChatRoomService, ChatMessageService, ChatGateway],
+  providers: [
+    ChatService,
+    ChatRoomService,
+    ChatMessageService,
+    PublicChatService,
+    ChatGateway,
+  ],
 })
 export class ChatModule {}

--- a/apps/chat/src/public-chat.service.ts
+++ b/apps/chat/src/public-chat.service.ts
@@ -1,0 +1,107 @@
+import { Injectable } from '@nestjs/common';
+import { MySQLPrismaService } from '@app/prisma';
+
+export interface PublicChatPayload {
+  clientId?: string;
+  userId?: number;
+  nickName?: string;
+  image?: string;
+  message?: string;
+}
+
+export interface PublicChatMessageView {
+  id: string;
+  clientId?: string;
+  userId?: number;
+  nickName: string;
+  image?: string;
+  message: string;
+  createdAt: string;
+}
+
+interface PublicChatRecord {
+  id: string;
+  clientId: string | null;
+  userId: number | null;
+  nickName: string;
+  image: string | null;
+  content: string;
+  createdAt: Date;
+}
+
+interface PublicChatModel {
+  create(args: { data: Record<string, unknown> }): Promise<PublicChatRecord>;
+  findMany(args: {
+    where: { deletedAt: null };
+    orderBy: { createdAt: 'desc' };
+    take: number;
+  }): Promise<PublicChatRecord[]>;
+}
+
+@Injectable()
+export class PublicChatService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async createMessage(
+    data: PublicChatPayload,
+  ): Promise<PublicChatMessageView | null> {
+    const message = data.message?.trim().slice(0, 500);
+    if (!message) return null;
+
+    const userId = this.normalizeUserId(data.userId);
+    const user = userId
+      ? await this.prisma.user.findFirst({
+          where: { id: userId, deletedAt: null },
+          select: { id: true, nickname: true, image: true },
+        })
+      : null;
+
+    const savedMessage = await this.publicChatModel.create({
+      data: {
+        clientId: data.clientId || null,
+        userId: user?.id ?? null,
+        nickName:
+          user?.nickname || data.nickName?.trim().slice(0, 24) || '익명',
+        image: user?.image || data.image?.trim() || null,
+        content: message,
+      },
+    });
+
+    return this.toView(savedMessage as PublicChatRecord);
+  }
+
+  async getHistory(): Promise<PublicChatMessageView[]> {
+    const messages = await this.publicChatModel.findMany({
+      where: { deletedAt: null },
+      orderBy: { createdAt: 'desc' },
+      take: 80,
+    });
+
+    return (messages as PublicChatRecord[])
+      .reverse()
+      .map((message) => this.toView(message));
+  }
+
+  private get publicChatModel() {
+    return this.prisma.publicChatMessage as unknown as PublicChatModel;
+  }
+
+  private toView(message: PublicChatRecord): PublicChatMessageView {
+    return {
+      id: message.id,
+      clientId: message.clientId || undefined,
+      userId: message.userId || undefined,
+      nickName: message.nickName,
+      image: message.image || undefined,
+      message: message.content,
+      createdAt: message.createdAt.toISOString(),
+    };
+  }
+
+  private normalizeUserId(userId?: number) {
+    const numericUserId = Number(userId);
+    return Number.isInteger(numericUserId) && numericUserId > 0
+      ? numericUserId
+      : null;
+  }
+}

--- a/prisma/migrations/20260627000000_public_chat_user_profile/migration.sql
+++ b/prisma/migrations/20260627000000_public_chat_user_profile/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `public_chat_messages`
+  ADD COLUMN `userId` INTEGER NULL AFTER `clientId`,
+  ADD COLUMN `image` LONGTEXT NULL AFTER `nickName`;
+
+CREATE INDEX `PublicChatMessage_userId_idx`
+  ON `public_chat_messages`(`userId`);

--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -237,12 +237,15 @@ model ChatMessage {
 model PublicChatMessage {
   id        String    @id @default(cuid())
   clientId  String?   @db.VarChar(191)
+  userId    Int?
   nickName  String    @db.VarChar(24)
+  image     String?   @db.LongText
   content   String    @db.VarChar(500)
   createdAt DateTime  @default(now()) @db.DateTime(6)
   deletedAt DateTime? @db.DateTime(6)
 
   @@index([createdAt], map: "PublicChatMessage_createdAt_idx")
+  @@index([userId], map: "PublicChatMessage_userId_idx")
   @@map("public_chat_messages")
 }
 


### PR DESCRIPTION
## Summary
공개채팅 메시지에 로그인 사용자 프로필 메타데이터를 저장하고, 공개채팅 접속자 수를 실시간으로 브로드캐스트합니다.

## 원인
프론트에서 상대방 아바타/1:1 채팅 진입/접속자 수를 안정적으로 표시하려면 서버가 userId, image, onlineCount를 제공해야 합니다.

## 변경
- PublicChatMessage에 userId, image 컬럼 및 마이그레이션 추가
- 공개채팅 저장/히스토리 변환을 PublicChatService로 분리
- /ws-public 접속/해제 시 onlineCount 이벤트 emit

## Test plan
- [x] pnpm exec tsc -p apps/chat/tsconfig.app.json --noEmit --incremental false
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)