### PR TITLE
✨ 공개 프로필 조회 API 추가

### DIFF
--- a/apps/api-gateway/src/user/user.controller.ts
+++ b/apps/api-gateway/src/user/user.controller.ts
@@ -5,7 +5,9 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   Logger,
+  Param,
   Patch,
   Post,
   Req,
@@ -45,6 +47,15 @@ export class UserController {
       });
     }
   }
+
+  @Get('/:id')
+  async find(@Param('id') id: string) {
+    const result = await firstValueFrom(
+      this.userService.find({ id: Number(id) }),
+    );
+    return convertToUserEntity(result);
+  }
+
   @Patch('/nickname')
   @UpdateUserSpecDecorator('회원정보 수정 API', '회원정보 수정')
   @UseGuards(JwtAuthGuard, RateLimitGuard)

--- a/apps/api-gateway/src/user/user.service.ts
+++ b/apps/api-gateway/src/user/user.service.ts
@@ -24,6 +24,10 @@ export class UserService implements OnModuleInit {
     return this.userService.createUser(createUserDto);
   }
 
+  find(findUserDto: { id: number }) {
+    return this.userService.findUser({ ...findUserDto });
+  }
+
   remove(deleteUserDto: { id: number }) {
     return this.userService.removeUser({ ...deleteUserDto });
   }

--- a/apps/user/src/user.controller.ts
+++ b/apps/user/src/user.controller.ts
@@ -1,5 +1,6 @@
 import {
   CreateUserDto,
+  FindUserDto,
   RemoveUserDto,
   UpdateUserDto,
   UpdateUserProfileImageDto,
@@ -18,6 +19,10 @@ export class UserController implements UserServiceController {
 
   createUser(createUserDto: CreateUserDto): Promise<User> {
     return this.userService.create(createUserDto);
+  }
+
+  findUser(findUserDto: FindUserDto): Promise<User> {
+    return this.userService.find(findUserDto);
   }
 
   removeUser(findOneUserDto: RemoveUserDto): Promise<User> {

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -1,5 +1,6 @@
 import {
   CreateUserDto,
+  FindUserDto,
   UpdateUserDto,
   UpdateUserProfileImageDto,
   User,
@@ -16,6 +17,19 @@ export class UserService {
     private readonly mysqlPrismaService: MySQLPrismaService,
     private readonly utilsService: UtilsService,
   ) {}
+
+  private toUser(user: any): User {
+    const deletedAt = user.deletedAt
+      ? this.utilsService.dateToTimestamp(user.deletedAt as Date)
+      : null;
+
+    return {
+      ...user,
+      createdAt: this.utilsService.dateToTimestamp(user.createdAt as Date),
+      updatedAt: this.utilsService.dateToTimestamp(user.updatedAt as Date),
+      deletedAt,
+    };
+  }
 
   async create(createUserDto: CreateUserDto): Promise<User> {
     const { email, password, nickname, marketingAgreed, gender } =
@@ -43,23 +57,7 @@ export class UserService {
         gender: gender as 'male' | 'female',
       },
     });
-    const createdAt = this.utilsService.dateToTimestamp(user.createdAt as Date);
-    const updatedAt = this.utilsService.dateToTimestamp(user.updatedAt as Date);
-    const deletedAt = user.deletedAt
-      ? this.utilsService.dateToTimestamp(user.deletedAt as Date)
-      : null;
-
-    const userObject: User = {
-      id: user.id,
-      email: user.email,
-      nickname: user.nickname,
-      image: user.image,
-      createdAt,
-      updatedAt,
-      deletedAt,
-      gender: user.gender,
-    };
-    return userObject;
+    return this.toUser(user);
   }
 
   async remove(id: number): Promise<User> {
@@ -73,27 +71,18 @@ export class UserService {
       where: { id },
       data: { deletedAt: new Date() },
     });
-    const createdAt = this.utilsService.dateToTimestamp(
-      deletedUser.createdAt as Date,
-    );
-    const updatedAt = this.utilsService.dateToTimestamp(
-      deletedUser.updatedAt as Date,
-    );
-    const deletedAt = this.utilsService.dateToTimestamp(
-      deletedUser.deletedAt as Date,
-    );
+    return this.toUser(deletedUser);
+  }
 
-    const userObject: User = {
-      id: deletedUser.id,
-      email: deletedUser.email,
-      nickname: deletedUser.nickname,
-      image: deletedUser.image,
-      createdAt,
-      updatedAt,
-      deletedAt,
-      gender: deletedUser.gender,
-    };
-    return userObject;
+  async find(findUserDto: FindUserDto): Promise<User> {
+    const userData = await this.mysqlPrismaService.user.findUnique({
+      where: { id: findUserDto.id },
+    });
+    if (!userData || userData.deletedAt) {
+      throw new NotFoundException(`User not found ${findUserDto.id}`);
+    }
+
+    return this.toUser(userData);
   }
 
   async updateUser(updateUserDto: UpdateUserDto): Promise<User> {
@@ -128,22 +117,7 @@ export class UserService {
       },
     });
 
-    const createdAt = this.utilsService.dateToTimestamp(
-      updatedUserData.createdAt as Date,
-    );
-    const updatedAt = this.utilsService.dateToTimestamp(
-      updatedUserData.updatedAt as Date,
-    );
-    const deletedAt = updatedUserData.deletedAt
-      ? this.utilsService.dateToTimestamp(updatedUserData.deletedAt as Date)
-      : null;
-
-    return {
-      ...updatedUserData,
-      createdAt,
-      updatedAt,
-      deletedAt,
-    };
+    return this.toUser(updatedUserData);
   }
 
   async updateUserProfileImage(
@@ -161,21 +135,6 @@ export class UserService {
       where: { id },
       data: { image: image },
     });
-    const createdAt = this.utilsService.dateToTimestamp(
-      updatedUserData.createdAt as Date,
-    );
-    const updatedAt = this.utilsService.dateToTimestamp(
-      updatedUserData.updatedAt as Date,
-    );
-    const deletedAt = updatedUserData.deletedAt
-      ? this.utilsService.dateToTimestamp(updatedUserData.deletedAt as Date)
-      : null;
-
-    return {
-      ...updatedUserData,
-      createdAt,
-      updatedAt,
-      deletedAt,
-    };
+    return this.toUser(updatedUserData);
   }
 }

--- a/libs/common/src/protobuf/user.ts
+++ b/libs/common/src/protobuf/user.ts
@@ -43,10 +43,16 @@ export interface RemoveUserDto {
   id: number;
 }
 
+export interface FindUserDto {
+  id: number;
+}
+
 export const USER_PACKAGE_NAME = 'user';
 
 export interface UserServiceClient {
   createUser(request: CreateUserDto): Observable<User>;
+
+  findUser(request: FindUserDto): Observable<User>;
 
   removeUser(request: RemoveUserDto): Observable<User>;
 
@@ -57,6 +63,8 @@ export interface UserServiceClient {
 
 export interface UserServiceController {
   createUser(request: CreateUserDto): Promise<User> | Observable<User> | User;
+
+  findUser(request: FindUserDto): Promise<User> | Observable<User> | User;
 
   removeUser(request: RemoveUserDto): Promise<User> | Observable<User> | User;
 
@@ -71,6 +79,7 @@ export function UserServiceControllerMethods() {
   return function (constructor: Function) {
     const grpcMethods: string[] = [
       'createUser',
+      'findUser',
       'removeUser',
       'updateUser',
       'updateUserProfileImage',

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -7,6 +7,7 @@ option go_package = "user";
 
 service UserService {
     rpc CreateUser(CreateUserDto) returns (User) {}
+    rpc FindUser(FindUserDto) returns (User) {}
     rpc RemoveUser (RemoveUserDto) returns (User) {}
     rpc UpdateUser (UpdateUserDto) returns (User) {}
     rpc UpdateUserProfileImage (UpdateUserProfileImageDto) returns (User) {}
@@ -45,5 +46,9 @@ message UpdateUserProfileImageDto {
     string image = 2;
 }
 message RemoveUserDto {
+    int32 id =1;
+}
+
+message FindUserDto {
     int32 id =1;
 }


### PR DESCRIPTION
## Summary
공개 프로필 화면에서 사용할 사용자 조회 API를 추가합니다.

## 변경
- user proto에 FindUser RPC 추가
- user 서비스에서 탈퇴 계정 제외 공개 조회 추가
- API Gateway에 GET /user/:id 라우트 추가

## Test plan
- [x] user 서비스 TypeScript noEmit 통과
- [x] API Gateway는 기존 notification Prisma 타입 이슈 외 user 변경 에러 없음
- [x] 수정 파일 200줄 상한 확인

Generated with Claude Code