### PR TITLE
✨ 회원가입 기본 프로필 이미지 지정

### DIFF
--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -1,4 +1,5 @@
 import { OutOfRangeException } from '@app/common/filters/rpcexception/rpc-exception';
+import { DEFAULT_PROFILE_IMAGE_URL } from '@app/common/constants/profile';
 import { AuthCommonResponse, User, ValidationResponse } from '@app/common/protobuf';
 import { MySQLPrismaService } from '@app/prisma';
 import { Inject, Injectable, Logger } from '@nestjs/common';
@@ -57,6 +58,7 @@ export class AuthService {
           provider,
           password: hashedPassword,
           nickname: null,
+          image: DEFAULT_PROFILE_IMAGE_URL,
         },
       });
       return {

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -6,6 +6,7 @@ import {
   User,
 } from '@app/common/protobuf';
 import { AlreadyExistsException } from '@app/common/filters/rpcexception/rpc-exception';
+import { DEFAULT_PROFILE_IMAGE_URL } from '@app/common/constants/profile';
 import { MySQLPrismaService } from '@app/prisma';
 import { UtilsService } from '@app/utils';
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
@@ -53,6 +54,7 @@ export class UserService {
         email,
         password: hashedPassword,
         nickname,
+        image: DEFAULT_PROFILE_IMAGE_URL,
         marketing_agreed: marketingAgreed,
         gender: gender as 'male' | 'female',
       },

--- a/libs/common/src/constants/profile.ts
+++ b/libs/common/src/constants/profile.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_PROFILE_IMAGE_URL =
+  'https://bollae-uploads-prod-058511778476-ap-northeast-2-an.s3.ap-northeast-2.amazonaws.com/profiles/2875139c-f1d8-44b3-b9fd-d39fc61be6e3.png';


### PR DESCRIPTION
## Summary
신규 가입 사용자에게 기본 프로필 이미지를 저장합니다.

## 변경
- 기본 프로필 이미지 URL 상수 추가
- 일반 회원가입 생성 시 image 기본값 지정
- Google OAuth 최초 가입 시 image 기본값 지정

## Test plan
- [x] user 서비스 TypeScript noEmit 통과
- [x] auth 서비스 TypeScript noEmit 통과
- [x] 수정 파일 200줄 상한 확인

Generated with Claude Code