### PR TITLE
✨ 닉네임 기반 공개 프로필 조회 추가

### DIFF
--- a/apps/api-gateway/src/chat/chat.controller.ts
+++ b/apps/api-gateway/src/chat/chat.controller.ts
@@ -41,11 +41,14 @@ export class ChatController {
   @UseGuards(JwtAuthGuard)
   async createChatRoom(@Body() body: CreateChatRoomRequest, @Req() req) {
     const userId = req.user.userId;
+    const memberIds = Array.from(
+      new Set([userId, ...(body.memberIds ?? [])]),
+    ).filter((id) => Number.isInteger(id) && id > 0);
     this.logger.log(`createChatRoom userId=${userId}`);
 
     return this.chatService.createChatRoom({
       ...body,
-      memberIds: [userId, ...body.memberIds], // 요청자도 멤버에 포함
+      memberIds,
     });
   }
 

--- a/apps/api-gateway/src/user/user.controller.ts
+++ b/apps/api-gateway/src/user/user.controller.ts
@@ -48,6 +48,16 @@ export class UserController {
     }
   }
 
+  @Get('/nickname/:nickname')
+  async findByNickname(@Param('nickname') nickname: string) {
+    const result = await firstValueFrom(
+      this.userService.findByNickname({
+        nickname: decodeURIComponent(nickname),
+      }),
+    );
+    return convertToUserEntity(result);
+  }
+
   @Get('/:id')
   async find(@Param('id') id: string) {
     const result = await firstValueFrom(

--- a/apps/api-gateway/src/user/user.service.ts
+++ b/apps/api-gateway/src/user/user.service.ts
@@ -28,6 +28,10 @@ export class UserService implements OnModuleInit {
     return this.userService.findUser({ ...findUserDto });
   }
 
+  findByNickname(findUserDto: { nickname: string }) {
+    return this.userService.findUserByNickname({ ...findUserDto });
+  }
+
   remove(deleteUserDto: { id: number }) {
     return this.userService.removeUser({ ...deleteUserDto });
   }

--- a/apps/user/src/user.controller.ts
+++ b/apps/user/src/user.controller.ts
@@ -1,5 +1,6 @@
 import {
   CreateUserDto,
+  FindUserByNicknameDto,
   FindUserDto,
   RemoveUserDto,
   UpdateUserDto,
@@ -23,6 +24,10 @@ export class UserController implements UserServiceController {
 
   findUser(findUserDto: FindUserDto): Promise<User> {
     return this.userService.find(findUserDto);
+  }
+
+  findUserByNickname(findUserDto: FindUserByNicknameDto): Promise<User> {
+    return this.userService.findByNickname(findUserDto);
   }
 
   removeUser(findOneUserDto: RemoveUserDto): Promise<User> {

--- a/apps/user/src/user.service.ts
+++ b/apps/user/src/user.service.ts
@@ -1,5 +1,6 @@
 import {
   CreateUserDto,
+  FindUserByNicknameDto,
   FindUserDto,
   UpdateUserDto,
   UpdateUserProfileImageDto,
@@ -82,6 +83,20 @@ export class UserService {
     });
     if (!userData || userData.deletedAt) {
       throw new NotFoundException(`User not found ${findUserDto.id}`);
+    }
+
+    return this.toUser(userData);
+  }
+
+  async findByNickname(
+    findUserDto: FindUserByNicknameDto,
+  ): Promise<User> {
+    const nickname = findUserDto.nickname?.trim();
+    const userData = await this.mysqlPrismaService.user.findFirst({
+      where: { nickname },
+    });
+    if (!userData || userData.deletedAt) {
+      throw new NotFoundException(`User not found ${nickname}`);
     }
 
     return this.toUser(userData);

--- a/libs/common/src/protobuf/user.ts
+++ b/libs/common/src/protobuf/user.ts
@@ -47,12 +47,18 @@ export interface FindUserDto {
   id: number;
 }
 
+export interface FindUserByNicknameDto {
+  nickname: string;
+}
+
 export const USER_PACKAGE_NAME = 'user';
 
 export interface UserServiceClient {
   createUser(request: CreateUserDto): Observable<User>;
 
   findUser(request: FindUserDto): Observable<User>;
+
+  findUserByNickname(request: FindUserByNicknameDto): Observable<User>;
 
   removeUser(request: RemoveUserDto): Observable<User>;
 
@@ -65,6 +71,10 @@ export interface UserServiceController {
   createUser(request: CreateUserDto): Promise<User> | Observable<User> | User;
 
   findUser(request: FindUserDto): Promise<User> | Observable<User> | User;
+
+  findUserByNickname(
+    request: FindUserByNicknameDto,
+  ): Promise<User> | Observable<User> | User;
 
   removeUser(request: RemoveUserDto): Promise<User> | Observable<User> | User;
 
@@ -80,6 +90,7 @@ export function UserServiceControllerMethods() {
     const grpcMethods: string[] = [
       'createUser',
       'findUser',
+      'findUserByNickname',
       'removeUser',
       'updateUser',
       'updateUserProfileImage',

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -8,6 +8,7 @@ option go_package = "user";
 service UserService {
     rpc CreateUser(CreateUserDto) returns (User) {}
     rpc FindUser(FindUserDto) returns (User) {}
+    rpc FindUserByNickname(FindUserByNicknameDto) returns (User) {}
     rpc RemoveUser (RemoveUserDto) returns (User) {}
     rpc UpdateUser (UpdateUserDto) returns (User) {}
     rpc UpdateUserProfileImage (UpdateUserProfileImageDto) returns (User) {}
@@ -51,4 +52,7 @@ message RemoveUserDto {
 
 message FindUserDto {
     int32 id =1;
+}
+message FindUserByNicknameDto {
+    string nickname = 1;
 }


### PR DESCRIPTION
## Summary
- user gRPC에 FindUserByNickname RPC 추가
- API Gateway에 GET /user/nickname/:nickname 추가
- 채팅방 생성 시 요청자/멤버 id 중복을 제거해 direct room 생성 500을 방어

## Test plan
- [x] `tsc -p apps/user/tsconfig.app.json --noEmit --incremental false`
- [x] `git diff --check`
- [x] 수정 파일 200줄 상한 확인
- [!] API Gateway tsc는 기존 notification Prisma 타입 이슈로 실패

🤖 Generated with Codex