### PR TITLE
✨ 감독 필모그래피 조회 API 추가

### DIFF
--- a/apps/api-gateway/src/movie/movie.controller.ts
+++ b/apps/api-gateway/src/movie/movie.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   Post,
+  Query,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -24,6 +25,27 @@ export class MovieController {
     try {
       const getRepliesObservable = await this.movieService.getMovieDatas();
       const data = await firstValueFrom(getRepliesObservable);
+      return data;
+    } catch (error) {
+      throw new RpcException({
+        code: error.code,
+        message: error.details,
+      });
+    }
+  }
+  @Get('/director')
+  async getMoviesByDirector(
+    @Query('name') name = '',
+    @Query('excludeMovieCd') excludeMovieCd = '0',
+    @Query('limit') limit = '12',
+  ) {
+    try {
+      const moviesObservable = await this.movieService.getMoviesByDirector({
+        name,
+        excludeMovieCd: +excludeMovieCd || 0,
+        limit: +limit || 12,
+      });
+      const data = await firstValueFrom(moviesObservable);
       return data;
     } catch (error) {
       throw new RpcException({

--- a/apps/api-gateway/src/movie/movie.service.ts
+++ b/apps/api-gateway/src/movie/movie.service.ts
@@ -27,6 +27,21 @@ export class MovieService implements OnModuleInit {
   async getMovieDetail(movieCd: number) {
     return await this.movieService.getMovieDetailData({ movieCd });
   }
+  async getMoviesByDirector({
+    name,
+    excludeMovieCd,
+    limit,
+  }: {
+    name: string;
+    excludeMovieCd: number;
+    limit: number;
+  }) {
+    return await this.movieService.getMoviesByDirector({
+      name,
+      excludeMovieCd,
+      limit,
+    });
+  }
   async upsertMovieScore({ userNumber, movieCd, score }) {
     return await this.movieService.upsertMovieScore({
       userId: userNumber,

--- a/apps/movie/src/movie-read.service.ts
+++ b/apps/movie/src/movie-read.service.ts
@@ -75,4 +75,39 @@ export class MovieReadService {
       },
     });
   }
+
+  async getMoviesByDirector({
+    name,
+    excludeMovieCd,
+    limit,
+  }: {
+    name: string;
+    excludeMovieCd: number;
+    limit: number;
+  }): Promise<MovieDatas> {
+    const directorName = name.trim();
+    if (!directorName) return { MovieData: [] };
+
+    const movieList = await this.prisma.movie.findMany({
+      where: {
+        director: { contains: directorName },
+        movieCd: { not: excludeMovieCd || 0 },
+      },
+      include: MOVIE_INCLUDE,
+      take: Math.min(Math.max(limit || 12, 1), 12),
+      orderBy: [{ openDt: 'desc' }, { rank: 'asc' }],
+    });
+
+    return {
+      MovieData: movieList.map((movieData) =>
+        convertMovieDataWithCounts({
+          ...movieData,
+          _count: {
+            Comment: movieData._count.Comment,
+            movieScores: movieData.movieScores?.length ?? 0,
+          },
+        }),
+      ),
+    };
+  }
 }

--- a/apps/movie/src/movie.controller.ts
+++ b/apps/movie/src/movie.controller.ts
@@ -9,6 +9,7 @@ import {
   RecommendMovieRequest,
   UpsertMovieScoreRequest,
   AverageMovieScore,
+  DirectorFilmographyRequest,
 } from '@app/common/protobuf';
 import { Controller } from '@nestjs/common';
 import { MovieService } from './movie.service';
@@ -31,6 +32,11 @@ export class MovieController implements MovieServiceController {
   }
   async getMovieDetailData(request: RecommendMovieRequest): Promise<MovieData> {
     return await this.movieService.getMovieDetail(request.movieCd);
+  }
+  async getMoviesByDirector(
+    request: DirectorFilmographyRequest,
+  ): Promise<MovieDatas> {
+    return await this.movieService.getMoviesByDirector(request);
   }
   async upsertMovieScore(
     request: UpsertMovieScoreRequest,

--- a/apps/movie/src/movie.service.ts
+++ b/apps/movie/src/movie.service.ts
@@ -26,6 +26,13 @@ export class MovieService {
   getMovieDetail(movieCd: number) {
     return this.readService.getMovieDetail(movieCd);
   }
+  getMoviesByDirector(req: {
+    name: string;
+    excludeMovieCd: number;
+    limit: number;
+  }) {
+    return this.readService.getMoviesByDirector(req);
+  }
 
   // Score
   upsertMovieScore(req: { movieCd: number; score: number; userId: number }) {

--- a/libs/common/src/protobuf/movie.ts
+++ b/libs/common/src/protobuf/movie.ts
@@ -29,6 +29,12 @@ export interface RecommendMovieRequest {
   movieCd: number;
 }
 
+export interface DirectorFilmographyRequest {
+  name: string;
+  excludeMovieCd: number;
+  limit: number;
+}
+
 export interface MovieData {
   id: number;
   movieCd: number;
@@ -81,6 +87,10 @@ export interface MovieServiceClient {
 
   getMovieDetailData(request: RecommendMovieRequest): Observable<MovieData>;
 
+  getMoviesByDirector(
+    request: DirectorFilmographyRequest,
+  ): Observable<MovieDatas>;
+
   upsertMovieScore(request: UpsertMovieScoreRequest): Observable<MovieScore>;
 
   getMovieScore(request: GetMovieScoreRequest): Observable<MovieScore>;
@@ -106,6 +116,10 @@ export interface MovieServiceController {
     request: RecommendMovieRequest,
   ): Promise<MovieData> | Observable<MovieData> | MovieData;
 
+  getMoviesByDirector(
+    request: DirectorFilmographyRequest,
+  ): Promise<MovieDatas> | Observable<MovieDatas> | MovieDatas;
+
   upsertMovieScore(
     request: UpsertMovieScoreRequest,
   ): Promise<MovieScore> | Observable<MovieScore> | MovieScore;
@@ -130,6 +144,7 @@ export function MovieServiceControllerMethods() {
       'fetchMovies',
       'recommendMovie',
       'getMovieDetailData',
+      'getMoviesByDirector',
       'upsertMovieScore',
       'getMovieScore',
       'getAverageMovieScore',

--- a/proto/movie.proto
+++ b/proto/movie.proto
@@ -11,6 +11,7 @@ service MovieService {
   rpc FetchMovies(common.Empty) returns (common.Empty) {}
   rpc RecommendMovie(RecommendMovieRequest) returns (MovieDatas) {}
   rpc GetMovieDetailData(RecommendMovieRequest) returns (MovieData) {}
+  rpc GetMoviesByDirector(DirectorFilmographyRequest) returns (MovieDatas) {}
   rpc UpsertMovieScore(UpsertMovieScoreRequest) returns (MovieScore) {}
   rpc GetMovieScore(GetMovieScoreRequest) returns (MovieScore) {}
   rpc GetAverageMovieScore(RecommendMovieRequest) returns (AverageMovieScore) {}
@@ -36,6 +37,11 @@ message MovieScore {
 }
 message RecommendMovieRequest {
   int32 movieCd = 1;
+}
+message DirectorFilmographyRequest {
+  string name = 1;
+  int32 excludeMovieCd = 2;
+  int32 limit = 3;
 }
 message MovieData {
   int32 id = 1;


### PR DESCRIPTION
## Summary
영화 상세에서 감독 필모그래피를 정확히 조회할 수 있도록 movie 서비스와 API Gateway에 감독명 기준 조회 API를 추가합니다.

## 변경
- movie gRPC `GetMoviesByDirector` RPC와 요청 메시지 추가
- movie-service에서 감독명 기준 영화 목록 조회 추가
- API Gateway `GET /movie/director?name=&excludeMovieCd=&limit=` 공개 라우트 추가

## Test plan
- [x] `pnpm exec tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false` 실행: 기존 notification Prisma 타입 오류만 남고 movie 변경 관련 오류 없음
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)