### PR TITLE
🐛 fix: 감독 필모그래피 외부 검색 보강

### DIFF
--- a/apps/movie/src/movie-director-filmography.service.ts
+++ b/apps/movie/src/movie-director-filmography.service.ts
@@ -1,0 +1,114 @@
+import { MovieData } from '@app/common/protobuf';
+import { KobisMovieListItem } from '@app/common/types/movie-response';
+import { MySQLPrismaService } from '@app/prisma';
+import { Injectable } from '@nestjs/common';
+import moment from 'moment';
+import { convertMovieDataWithCounts } from './movie.formatter';
+import { MovieMetadataClient } from './movie-metadata.client';
+
+const MOVIE_INCLUDE = {
+  MovieVod: true,
+  movieScores: true,
+  _count: {
+    select: {
+      Comment: { where: { deletedAt: null } },
+    },
+  },
+} as const;
+
+@Injectable()
+export class MovieDirectorFilmographyService {
+  private readonly metadataClient = new MovieMetadataClient();
+
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async fillFromKofic({
+    directorName,
+    excludeMovieCd,
+    excludedMovieCds,
+    limit,
+  }: {
+    directorName: string;
+    excludeMovieCd: number;
+    excludedMovieCds: number[];
+    limit: number;
+  }): Promise<MovieData[]> {
+    const candidates = await this.metadataClient.fetchKoficMoviesByDirector(
+      directorName,
+      limit + excludedMovieCds.length + 1,
+    );
+    const excluded = new Set([excludeMovieCd, ...excludedMovieCds]);
+    const movies = candidates
+      .filter((movie) => !excluded.has(Number(movie.movieCd)))
+      .slice(0, limit);
+
+    const upserted = await Promise.all(
+      movies.map((movie) => this.upsertKoficMovie(movie, directorName)),
+    );
+
+    return upserted.map((movieData) =>
+      convertMovieDataWithCounts({
+        ...movieData,
+        _count: {
+          Comment: movieData._count.Comment,
+          movieScores: movieData.movieScores?.length ?? 0,
+        },
+      }),
+    );
+  }
+
+  private async upsertKoficMovie(
+    movie: KobisMovieListItem,
+    directorName: string,
+  ) {
+    const movieCd = Number(movie.movieCd) || 0;
+    const openedAt = this.parseKoficOpenDate(movie.openDt, movie.prdtYear);
+    const director = this.getDirectorNames(movie) || directorName;
+    const genre = movie.genreAlt || movie.repGenreNm || '';
+
+    return this.prisma.movie.upsert({
+      where: { movieCd },
+      update: {
+        title: movie.movieNm,
+        openDt: openedAt,
+        director,
+        ...(genre && { genre }),
+      },
+      create: {
+        movieCd,
+        title: movie.movieNm,
+        audience: 0,
+        rank: 0,
+        vector: [],
+        poster: '',
+        rankInten: '',
+        rankOldAndNew: '',
+        openDt: openedAt,
+        plot: '',
+        director,
+        genre,
+        ratting: '',
+      },
+      include: MOVIE_INCLUDE,
+    });
+  }
+
+  private getDirectorNames(movie: KobisMovieListItem) {
+    return (
+      movie.directors
+        ?.map((director) => director.peopleNm?.trim())
+        ?.filter(Boolean)
+        ?.join(', ') ?? ''
+    );
+  }
+
+  private parseKoficOpenDate(openDt: string, prdtYear: string): Date {
+    if (/^\d{8}$/.test(openDt)) {
+      return moment(openDt, 'YYYYMMDD').toDate();
+    }
+    if (/^\d{4}$/.test(prdtYear)) {
+      return moment(`${prdtYear}0101`, 'YYYYMMDD').toDate();
+    }
+    return new Date(0);
+  }
+}

--- a/apps/movie/src/movie-metadata.client.ts
+++ b/apps/movie/src/movie-metadata.client.ts
@@ -1,6 +1,8 @@
 import {
   KmdbMovie,
   KmdbResponse,
+  KobisMovieListItem,
+  KobisMovieListResponse,
   KobisMovie,
   KobisMovieDetailResponse,
   KobisResponse,
@@ -24,6 +26,8 @@ export class MovieMetadataClient {
     'http://www.kobis.or.kr/kobisopenapi/webservice/rest/boxoffice/searchDailyBoxOfficeList.json';
   private readonly koficMovieDetailUrl =
     'http://www.kobis.or.kr/kobisopenapi/webservice/rest/movie/searchMovieInfo.json';
+  private readonly koficMovieListUrl =
+    'http://www.kobis.or.kr/kobisopenapi/webservice/rest/movie/searchMovieList.json';
   private readonly kmdbUrl =
     'http://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp';
 
@@ -46,6 +50,34 @@ export class MovieMetadataClient {
     } catch (error) {
       this.logger.warn(`fetchKoficMetadata failed for "${movieCd}": ${error}`);
       return { director: '', genre: '', rating: '' };
+    }
+  }
+
+  async fetchKoficMoviesByDirector(
+    directorName: string,
+    limit: number,
+  ): Promise<KobisMovieListItem[]> {
+    if (!this.koficKey || !directorName.trim()) return [];
+
+    try {
+      const url = `${this.koficMovieListUrl}?key=${
+        this.koficKey
+      }&directorNm=${encodeURIComponent(directorName)}&curPage=1&itemPerPage=${
+        limit || 12
+      }`;
+      const response = await axios.get<KobisMovieListResponse>(url);
+      const movies = response.data?.movieListResult?.movieList ?? [];
+      return movies.filter(
+        (movie) =>
+          movie.directors?.some(
+            (director) => director.peopleNm?.trim() === directorName.trim(),
+          ),
+      );
+    } catch (error) {
+      this.logger.warn(
+        `fetchKoficMoviesByDirector failed for "${directorName}": ${error}`,
+      );
+      return [];
     }
   }
 

--- a/apps/movie/src/movie-read.service.ts
+++ b/apps/movie/src/movie-read.service.ts
@@ -7,6 +7,7 @@ import { MySQLPrismaService } from '@app/prisma';
 import { MovieData, MovieDatas } from '@app/common/protobuf';
 import moment from 'moment';
 import { convertMovieDataWithCounts } from './movie.formatter';
+import { MovieDirectorFilmographyService } from './movie-director-filmography.service';
 
 const MOVIE_INCLUDE = {
   MovieVod: true,
@@ -20,7 +21,10 @@ const MOVIE_INCLUDE = {
 
 @Injectable()
 export class MovieReadService {
-  constructor(private readonly prisma: MySQLPrismaService) {}
+  constructor(
+    private readonly prisma: MySQLPrismaService,
+    private readonly directorFilmography: MovieDirectorFilmographyService,
+  ) {}
 
   async getMovieDatas(): Promise<Omit<MovieDatas, 'vector'>> {
     const now = moment();
@@ -88,26 +92,36 @@ export class MovieReadService {
     const directorName = name.trim();
     if (!directorName) return { MovieData: [] };
 
+    const take = Math.min(Math.max(limit || 12, 1), 12);
     const movieList = await this.prisma.movie.findMany({
       where: {
         director: { contains: directorName },
         movieCd: { not: excludeMovieCd || 0 },
       },
       include: MOVIE_INCLUDE,
-      take: Math.min(Math.max(limit || 12, 1), 12),
+      take,
       orderBy: [{ openDt: 'desc' }, { rank: 'asc' }],
     });
 
-    return {
-      MovieData: movieList.map((movieData) =>
-        convertMovieDataWithCounts({
-          ...movieData,
-          _count: {
-            Comment: movieData._count.Comment,
-            movieScores: movieData.movieScores?.length ?? 0,
-          },
-        }),
-      ),
-    };
+    const dbMovies = movieList.map((movieData) =>
+      convertMovieDataWithCounts({
+        ...movieData,
+        _count: {
+          Comment: movieData._count.Comment,
+          movieScores: movieData.movieScores?.length ?? 0,
+        },
+      }),
+    );
+    const externalMovies =
+      dbMovies.length < take
+        ? await this.directorFilmography.fillFromKofic({
+            directorName,
+            excludeMovieCd,
+            excludedMovieCds: dbMovies.map((movie) => movie.movieCd),
+            limit: take - dbMovies.length,
+          })
+        : [];
+
+    return { MovieData: [...dbMovies, ...externalMovies] };
   }
 }

--- a/apps/movie/src/movie.module.ts
+++ b/apps/movie/src/movie.module.ts
@@ -5,6 +5,7 @@ import { MovieSyncService } from './movie-sync.service';
 import { MovieReadService } from './movie-read.service';
 import { MovieScoreService } from './movie-score.service';
 import { MoviePosterStorageService } from './movie-poster-storage.service';
+import { MovieDirectorFilmographyService } from './movie-director-filmography.service';
 import { PrismaModule } from '@app/prisma';
 import { UtilsModule } from '@app/utils';
 
@@ -17,6 +18,7 @@ import { UtilsModule } from '@app/utils';
     MovieReadService,
     MovieScoreService,
     MoviePosterStorageService,
+    MovieDirectorFilmographyService,
   ],
 })
 export class MovieModule {}

--- a/libs/common/src/types/movie-response.ts
+++ b/libs/common/src/types/movie-response.ts
@@ -164,3 +164,22 @@ export interface KobisMovieDetailResponse {
     };
   };
 }
+
+export interface KobisMovieListItem {
+  movieCd: string;
+  movieNm: string;
+  prdtYear: string;
+  openDt: string;
+  genreAlt: string;
+  repGenreNm: string;
+  directors: {
+    peopleNm: string;
+  }[];
+}
+
+export interface KobisMovieListResponse {
+  movieListResult: {
+    totCnt: number;
+    movieList: KobisMovieListItem[];
+  };
+}


### PR DESCRIPTION
## Summary
- 감독 필모그래피 조회가 DB 결과만으로 부족할 때 KOFIC 감독 검색 결과로 보강합니다.
- 외부 검색으로 찾은 영화는 최소 영화 정보로 DB에 upsert해 카드 클릭 시 `/movie/{movieCd}` 상세 화면이 열리도록 했습니다.
- 기존 DB 영화는 포스터/평점/댓글 카운트가 유지되도록 우선 반환합니다.

## Cause
- 기존 `/movie/director`는 현재 DB의 `Movie.director contains name`만 조회했습니다.
- 운영 DB는 박스오피스 중심으로 채워져 있어 `군체` 외 연상호 감독의 과거작이 없으면 `[]`가 반환됐습니다.

## Test plan
- [x] `pnpm exec tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인
- [x] 커밋 대상 파일 `git diff --check` 통과

🤖 Generated with Codex