### PR TITLE
🐛 fix: 필모그래피 포스터와 홈 랭킹 분리

### DIFF
--- a/apps/movie/src/movie-director-filmography.service.ts
+++ b/apps/movie/src/movie-director-filmography.service.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@nestjs/common';
 import moment from 'moment';
 import { convertMovieDataWithCounts } from './movie.formatter';
 import { MovieMetadataClient } from './movie-metadata.client';
+import { MoviePosterStorageService } from './movie-poster-storage.service';
 
 const MOVIE_INCLUDE = {
   MovieVod: true,
@@ -20,7 +21,10 @@ const MOVIE_INCLUDE = {
 export class MovieDirectorFilmographyService {
   private readonly metadataClient = new MovieMetadataClient();
 
-  constructor(private readonly prisma: MySQLPrismaService) {}
+  constructor(
+    private readonly prisma: MySQLPrismaService,
+    private readonly posterStorage: MoviePosterStorageService,
+  ) {}
 
   async fillFromKofic({
     directorName,
@@ -64,7 +68,8 @@ export class MovieDirectorFilmographyService {
     const movieCd = Number(movie.movieCd) || 0;
     const openedAt = this.parseKoficOpenDate(movie.openDt, movie.prdtYear);
     const director = this.getDirectorNames(movie) || directorName;
-    const genre = movie.genreAlt || movie.repGenreNm || '';
+    const metadata = await this.fetchMetadata(movie, movieCd);
+    const genre = metadata.genre || movie.genreAlt || movie.repGenreNm || '';
 
     return this.prisma.movie.upsert({
       where: { movieCd },
@@ -72,7 +77,10 @@ export class MovieDirectorFilmographyService {
         title: movie.movieNm,
         openDt: openedAt,
         director,
+        ...(metadata.poster && { poster: metadata.poster }),
+        ...(metadata.plot && { plot: metadata.plot }),
         ...(genre && { genre }),
+        ...(metadata.rating && { ratting: metadata.rating }),
       },
       create: {
         movieCd,
@@ -80,17 +88,42 @@ export class MovieDirectorFilmographyService {
         audience: 0,
         rank: 0,
         vector: [],
-        poster: '',
+        poster: metadata.poster,
         rankInten: '',
         rankOldAndNew: '',
         openDt: openedAt,
-        plot: '',
+        plot: metadata.plot,
         director,
         genre,
-        ratting: '',
+        ratting: metadata.rating,
       },
       include: MOVIE_INCLUDE,
     });
+  }
+
+  private async fetchMetadata(movie: KobisMovieListItem, movieCd: number) {
+    const title = movie.movieNm ?? '';
+    const [koficMetadata, kmdbData, tmdbData] = await Promise.all([
+      this.metadataClient.fetchKoficMetadata(movie.movieCd),
+      this.metadataClient.fetchKmdbData(title),
+      this.metadataClient.fetchTmdbData(title),
+    ]);
+    const poster =
+      (tmdbData?.poster_path
+        ? `https://image.tmdb.org/t/p/w500${tmdbData.poster_path}`
+        : '') ||
+      kmdbData?.posters ||
+      '';
+
+    return {
+      poster: await this.posterStorage.mirrorPoster(poster, movieCd),
+      plot:
+        tmdbData?.overview ||
+        kmdbData?.plots?.plot?.[0]?.plotText?.trim() ||
+        '',
+      genre: koficMetadata.genre || kmdbData?.genre || '',
+      rating: koficMetadata.rating || kmdbData?.rating || '',
+    };
   }
 
   private getDirectorNames(movie: KobisMovieListItem) {

--- a/apps/movie/src/movie-read.service.ts
+++ b/apps/movie/src/movie-read.service.ts
@@ -38,7 +38,10 @@ export class MovieReadService {
     }
 
     const movieList = await this.prisma.movie.findMany({
-      where: { updatedAt: { gte: new Date(dateObject) } },
+      where: {
+        updatedAt: { gte: new Date(dateObject) },
+        rank: { gt: 0 },
+      },
       include: MOVIE_INCLUDE,
       take: 10,
       orderBy: [{ rank: 'asc' }],


### PR DESCRIPTION
## Summary
- 홈 TOP10 조회에서 `rank > 0` 조건을 추가해 감독 필모그래피 fallback 영화가 홈 목록에 섞이지 않도록 했습니다.
- KOFIC fallback 필모그래피 영화 저장 시 KOFIC/KMDB/TMDB 메타데이터를 보강하고 포스터를 S3로 미러링해 저장합니다.

## Cause
- 감독 필모그래피 fallback 영화가 `rank=0`, `updatedAt=오늘`로 upsert되면서 홈 TOP10의 `updatedAt >= today` + `rank asc` 조건에 먼저 잡혔습니다.
- fallback upsert가 최소 정보만 저장해 포스터가 비어 있었습니다.

## Test plan
- [x] `pnpm exec tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인
- [x] 커밋 대상 파일 `git diff --check` 통과

🤖 Generated with Codex