### PR TITLE
🐛 fix: 기존 필모그래피 포스터 보강

### DIFF
--- a/apps/movie/src/movie-director-filmography.service.ts
+++ b/apps/movie/src/movie-director-filmography.service.ts
@@ -26,6 +26,49 @@ export class MovieDirectorFilmographyService {
     private readonly posterStorage: MoviePosterStorageService,
   ) {}
 
+  async enrichStoredFallbackMovies<T extends { movieCd: number; rank: bigint }>(
+    movies: T[],
+  ): Promise<T[]> {
+    return Promise.all(
+      movies.map(async (movie) => {
+        if (!this.needsMetadata(movie)) return movie;
+
+        const metadata = await this.fetchMetadata(
+          {
+            movieCd: String(movie.movieCd),
+            movieNm: (movie as any).title ?? '',
+            prdtYear: '',
+            openDt: '',
+            genreAlt: (movie as any).genre ?? '',
+            repGenreNm: '',
+            directors: [],
+          },
+          movie.movieCd,
+        );
+
+        if (
+          !metadata.poster &&
+          !metadata.plot &&
+          !metadata.genre &&
+          !metadata.rating
+        ) {
+          return movie;
+        }
+
+        return (await this.prisma.movie.update({
+          where: { movieCd: movie.movieCd },
+          data: {
+            ...(metadata.poster && { poster: metadata.poster }),
+            ...(metadata.plot && { plot: metadata.plot }),
+            ...(metadata.genre && { genre: metadata.genre }),
+            ...(metadata.rating && { ratting: metadata.rating }),
+          },
+          include: MOVIE_INCLUDE,
+        })) as unknown as T;
+      }),
+    );
+  }
+
   async fillFromKofic({
     directorName,
     excludeMovieCd,
@@ -99,6 +142,10 @@ export class MovieDirectorFilmographyService {
       },
       include: MOVIE_INCLUDE,
     });
+  }
+
+  private needsMetadata(movie: any): boolean {
+    return Number(movie.rank) === 0 && (!movie.poster || !movie.plot);
   }
 
   private async fetchMetadata(movie: KobisMovieListItem, movieCd: number) {

--- a/apps/movie/src/movie-read.service.ts
+++ b/apps/movie/src/movie-read.service.ts
@@ -106,7 +106,9 @@ export class MovieReadService {
       orderBy: [{ openDt: 'desc' }, { rank: 'asc' }],
     });
 
-    const dbMovies = movieList.map((movieData) =>
+    const enrichedMovieList =
+      await this.directorFilmography.enrichStoredFallbackMovies(movieList);
+    const dbMovies = enrichedMovieList.map((movieData) =>
       convertMovieDataWithCounts({
         ...movieData,
         _count: {


### PR DESCRIPTION
## Summary
- 이미 DB에 저장된 감독 필모그래피 fallback 영화도 `rank=0`이고 포스터/줄거리가 비어 있으면 조회 시 메타데이터를 보강합니다.
- 보강 포스터는 기존과 동일하게 S3로 미러링합니다.
- 홈 TOP10은 직전 PR의 `rank > 0` 조건으로 fallback 영화 유입을 막은 상태입니다.

## Test plan
- [x] `pnpm exec tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인
- [x] 커밋 대상 파일 `git diff --check` 통과

🤖 Generated with Codex