### PR TITLE
🐛 fix: 필모그래피 보강 실패 방어

### DIFF
--- a/apps/movie/src/movie-director-filmography.service.ts
+++ b/apps/movie/src/movie-director-filmography.service.ts
@@ -150,27 +150,31 @@ export class MovieDirectorFilmographyService {
 
   private async fetchMetadata(movie: KobisMovieListItem, movieCd: number) {
     const title = movie.movieNm ?? '';
-    const [koficMetadata, kmdbData, tmdbData] = await Promise.all([
-      this.metadataClient.fetchKoficMetadata(movie.movieCd),
-      this.metadataClient.fetchKmdbData(title),
-      this.metadataClient.fetchTmdbData(title),
-    ]);
-    const poster =
-      (tmdbData?.poster_path
-        ? `https://image.tmdb.org/t/p/w500${tmdbData.poster_path}`
-        : '') ||
-      kmdbData?.posters ||
-      '';
+    try {
+      const [koficMetadata, kmdbData, tmdbData] = await Promise.all([
+        this.metadataClient.fetchKoficMetadata(movie.movieCd),
+        this.metadataClient.fetchKmdbData(title),
+        this.metadataClient.fetchTmdbData(title),
+      ]);
+      const poster =
+        (tmdbData?.poster_path
+          ? `https://image.tmdb.org/t/p/w500${tmdbData.poster_path}`
+          : '') ||
+        kmdbData?.posters ||
+        '';
 
-    return {
-      poster: await this.posterStorage.mirrorPoster(poster, movieCd),
-      plot:
-        tmdbData?.overview ||
-        kmdbData?.plots?.plot?.[0]?.plotText?.trim() ||
-        '',
-      genre: koficMetadata.genre || kmdbData?.genre || '',
-      rating: koficMetadata.rating || kmdbData?.rating || '',
-    };
+      return {
+        poster: await this.posterStorage.mirrorPoster(poster, movieCd),
+        plot:
+          tmdbData?.overview ||
+          kmdbData?.plots?.plot?.[0]?.plotText?.trim() ||
+          '',
+        genre: koficMetadata.genre || kmdbData?.genre || '',
+        rating: koficMetadata.rating || kmdbData?.rating || '',
+      };
+    } catch {
+      return { poster: '', plot: '', genre: '', rating: '' };
+    }
   }
 
   private getDirectorNames(movie: KobisMovieListItem) {


### PR DESCRIPTION
## Summary
- 필모그래피 포스터/메타데이터 보강 중 KMDB/TMDB 등 외부 호출이 실패해도 `/movie/director` API 전체가 500이 되지 않도록 방어했습니다.
- 보강 실패 시 기존 목록은 그대로 반환합니다.

## Test plan
- [x] `pnpm exec tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인
- [x] 커밋 대상 파일 `git diff --check` 통과

🤖 Generated with Codex