### PR TITLE
⚡️ 감독 필모그래피 캐시 저장

### DIFF
--- a/apps/movie/src/movie-director-filmography-cache.service.ts
+++ b/apps/movie/src/movie-director-filmography-cache.service.ts
@@ -1,0 +1,133 @@
+import { MovieData } from '@app/common/protobuf';
+import { MySQLPrismaService } from '@app/prisma';
+import { Injectable } from '@nestjs/common';
+import { convertMovieDataWithCounts } from './movie.formatter';
+
+const MOVIE_INCLUDE = {
+  MovieVod: true,
+  movieScores: true,
+  _count: {
+    select: {
+      Comment: { where: { deletedAt: null } },
+    },
+  },
+} as const;
+
+@Injectable()
+export class MovieDirectorFilmographyCacheService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async findCached({
+    directorName,
+    excludeMovieCd,
+    limit,
+  }: {
+    directorName: string;
+    excludeMovieCd: number;
+    limit: number;
+  }): Promise<MovieData[]> {
+    const rows = await this.prisma.directorFilmography.findMany({
+      where: {
+        directorName,
+        movieCd: { not: excludeMovieCd || 0 },
+      },
+      include: { Movie: { include: MOVIE_INCLUDE } },
+      orderBy: [{ sortOrder: 'asc' }, { Movie: { openDt: 'desc' } }],
+      take: limit,
+    });
+
+    return rows.map((row) => this.toMovieData(row.Movie));
+  }
+
+  async seedFromMovieTable({
+    directorName,
+    excludeMovieCd,
+    limit,
+  }: {
+    directorName: string;
+    excludeMovieCd: number;
+    limit: number;
+  }): Promise<MovieData[]> {
+    const movies = await this.prisma.movie.findMany({
+      where: {
+        director: { contains: directorName },
+        movieCd: { not: excludeMovieCd || 0 },
+      },
+      include: MOVIE_INCLUDE,
+      take: limit,
+      orderBy: [{ openDt: 'desc' }, { rank: 'asc' }],
+    });
+
+    await this.saveMovieCodes({
+      directorName,
+      movieCds: movies.map((movie) => movie.movieCd),
+      source: 'db',
+    });
+
+    return movies.map((movie) => this.toMovieData(movie));
+  }
+
+  async saveMovieData({
+    directorName,
+    movies,
+    source,
+    startOrder = 0,
+  }: {
+    directorName: string;
+    movies: MovieData[];
+    source: string;
+    startOrder?: number;
+  }): Promise<void> {
+    await this.saveMovieCodes({
+      directorName,
+      movieCds: movies.map((movie) => movie.movieCd),
+      source,
+      startOrder,
+    });
+  }
+
+  private async saveMovieCodes({
+    directorName,
+    movieCds,
+    source,
+    startOrder = 0,
+  }: {
+    directorName: string;
+    movieCds: number[];
+    source: string;
+    startOrder?: number;
+  }): Promise<void> {
+    await Promise.all(
+      movieCds.map((movieCd, index) =>
+        this.prisma.directorFilmography.upsert({
+          where: {
+            directorName_movieCd: {
+              directorName,
+              movieCd,
+            },
+          },
+          update: {
+            sortOrder: startOrder + index,
+            source,
+          },
+          create: {
+            directorName,
+            movieCd,
+            sortOrder: startOrder + index,
+            source,
+          },
+        }),
+      ),
+    );
+  }
+
+  private toMovieData(movieData: any): MovieData {
+    return convertMovieDataWithCounts({
+      ...movieData,
+      _count: {
+        Comment: movieData._count.Comment,
+        movieScores: movieData.movieScores?.length ?? 0,
+      },
+    });
+  }
+}

--- a/apps/movie/src/movie-read.service.ts
+++ b/apps/movie/src/movie-read.service.ts
@@ -8,6 +8,7 @@ import { MovieData, MovieDatas } from '@app/common/protobuf';
 import moment from 'moment';
 import { convertMovieDataWithCounts } from './movie.formatter';
 import { MovieDirectorFilmographyService } from './movie-director-filmography.service';
+import { MovieDirectorFilmographyCacheService } from './movie-director-filmography-cache.service';
 
 const MOVIE_INCLUDE = {
   MovieVod: true,
@@ -24,6 +25,7 @@ export class MovieReadService {
   constructor(
     private readonly prisma: MySQLPrismaService,
     private readonly directorFilmography: MovieDirectorFilmographyService,
+    private readonly filmographyCache: MovieDirectorFilmographyCacheService,
   ) {}
 
   async getMovieDatas(): Promise<Omit<MovieDatas, 'vector'>> {
@@ -96,37 +98,62 @@ export class MovieReadService {
     if (!directorName) return { MovieData: [] };
 
     const take = Math.min(Math.max(limit || 12, 1), 12);
-    const movieList = await this.prisma.movie.findMany({
-      where: {
-        director: { contains: directorName },
-        movieCd: { not: excludeMovieCd || 0 },
-      },
-      include: MOVIE_INCLUDE,
-      take,
-      orderBy: [{ openDt: 'desc' }, { rank: 'asc' }],
+    const cachedMovies = await this.filmographyCache.findCached({
+      directorName,
+      excludeMovieCd,
+      limit: take,
     });
 
-    const enrichedMovieList =
-      await this.directorFilmography.enrichStoredFallbackMovies(movieList);
-    const dbMovies = enrichedMovieList.map((movieData) =>
-      convertMovieDataWithCounts({
-        ...movieData,
-        _count: {
-          Comment: movieData._count.Comment,
-          movieScores: movieData.movieScores?.length ?? 0,
-        },
-      }),
-    );
-    const externalMovies =
-      dbMovies.length < take
-        ? await this.directorFilmography.fillFromKofic({
-            directorName,
-            excludeMovieCd,
-            excludedMovieCds: dbMovies.map((movie) => movie.movieCd),
-            limit: take - dbMovies.length,
-          })
-        : [];
+    if (cachedMovies.length >= take) {
+      return { MovieData: cachedMovies };
+    }
 
-    return { MovieData: [...dbMovies, ...externalMovies] };
+    const dbMovies = await this.filmographyCache.seedFromMovieTable({
+      directorName,
+      excludeMovieCd,
+      limit: take,
+    });
+    const movies =
+      dbMovies.length > cachedMovies.length ? dbMovies : cachedMovies;
+
+    if (movies.length < take) {
+      this.queueExternalFilmographyFill({
+        directorName,
+        excludeMovieCd,
+        movies,
+        limit: take - movies.length,
+      });
+    }
+
+    return { MovieData: movies };
+  }
+
+  private queueExternalFilmographyFill({
+    directorName,
+    excludeMovieCd,
+    movies,
+    limit,
+  }: {
+    directorName: string;
+    excludeMovieCd: number;
+    movies: MovieData[];
+    limit: number;
+  }): void {
+    void this.directorFilmography
+      .fillFromKofic({
+        directorName,
+        excludeMovieCd,
+        excludedMovieCds: movies.map((movie) => movie.movieCd),
+        limit,
+      })
+      .then((externalMovies) =>
+        this.filmographyCache.saveMovieData({
+          directorName,
+          movies: externalMovies,
+          source: 'kofic',
+          startOrder: movies.length,
+        }),
+      )
+      .catch(() => undefined);
   }
 }

--- a/apps/movie/src/movie.module.ts
+++ b/apps/movie/src/movie.module.ts
@@ -6,6 +6,7 @@ import { MovieReadService } from './movie-read.service';
 import { MovieScoreService } from './movie-score.service';
 import { MoviePosterStorageService } from './movie-poster-storage.service';
 import { MovieDirectorFilmographyService } from './movie-director-filmography.service';
+import { MovieDirectorFilmographyCacheService } from './movie-director-filmography-cache.service';
 import { PrismaModule } from '@app/prisma';
 import { UtilsModule } from '@app/utils';
 
@@ -19,6 +20,7 @@ import { UtilsModule } from '@app/utils';
     MovieScoreService,
     MoviePosterStorageService,
     MovieDirectorFilmographyService,
+    MovieDirectorFilmographyCacheService,
   ],
 })
 export class MovieModule {}

--- a/prisma/migrations/20260629000000_add_director_filmography_cache/migration.sql
+++ b/prisma/migrations/20260629000000_add_director_filmography_cache/migration.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `DirectorFilmography` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `directorName` VARCHAR(100) NOT NULL,
+    `movieCd` INTEGER NOT NULL,
+    `sortOrder` INTEGER NOT NULL DEFAULT 0,
+    `source` VARCHAR(20) NOT NULL DEFAULT 'db',
+    `createdAt` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    `updatedAt` DATETIME(6) NOT NULL,
+
+    UNIQUE INDEX `DirectorFilmography_director_movie_unique`(`directorName`, `movieCd`),
+    INDEX `DirectorFilmography_director_sort_idx`(`directorName`, `sortOrder`),
+    INDEX `DirectorFilmography_movieCd_idx`(`movieCd`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `DirectorFilmography`
+  ADD CONSTRAINT `DirectorFilmography_movieCd_fkey`
+  FOREIGN KEY (`movieCd`) REFERENCES `Movie`(`movieCd`)
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -43,9 +43,25 @@ model Movie {
   ratting       String?      @db.VarChar(100)
   Comment       Comment[]
   MovieVod      MovieVod[]
+  DirectorFilmography DirectorFilmography[]
   movieScores   movieScore[]
 
   @@index([movieCd], map: "movieId")
+}
+
+model DirectorFilmography {
+  id           Int      @id @default(autoincrement())
+  directorName String   @db.VarChar(100)
+  movieCd      Int
+  sortOrder    Int      @default(0)
+  source       String   @default("db") @db.VarChar(20)
+  createdAt    DateTime @default(now()) @db.DateTime(6)
+  updatedAt    DateTime @updatedAt @db.DateTime(6)
+  Movie        Movie    @relation(fields: [movieCd], references: [movieCd], onDelete: Cascade)
+
+  @@unique([directorName, movieCd], map: "DirectorFilmography_director_movie_unique")
+  @@index([directorName, sortOrder], map: "DirectorFilmography_director_sort_idx")
+  @@index([movieCd], map: "DirectorFilmography_movieCd_idx")
 }
 
 model User {


### PR DESCRIPTION
## Summary
감독 필모그래피 조회 결과를 DB에 캐시해 `/movie/director` 응답이 외부 API 보강을 기다리지 않도록 개선합니다.

## 원인
기존 구현은 필모그래피 조회 중 KOFIC/KMDB/TMDB 보강과 S3 포스터 미러링이 함께 실행되어, 최초/누락 데이터 조회가 느려질 수 있었습니다.

## 변경
- `DirectorFilmography` 캐시 테이블과 migration 추가
- `/movie/director` 조회를 캐시 우선으로 변경
- 캐시가 없으면 기존 `Movie` 테이블에서 빠르게 시드
- 부족한 KOFIC 보강은 응답 이후 저장 처리
- Prisma schema는 단일 스키마 파일이라 200줄 초과 예외로 유지

## Test plan
- [x] `pnpm exec tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] `DATABASE_URL=mysql://user:pass@127.0.0.1:3306/db pnpm exec prisma validate --schema prisma/mysql.schema.prisma`
- [x] 수정 소스 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)