### PR TITLE
🐛 영화 목록 빈 화면 방지

### DIFF
--- a/apps/cron/src/cron.service.ts
+++ b/apps/cron/src/cron.service.ts
@@ -6,8 +6,17 @@ import { MovieService } from './movie/movie.service';
 export class CronService {
   constructor(private readonly movieService: MovieService) {}
 
-  @Cron('0 10 0 * * *')
-  handleCron() {
-    this.movieService.fetchMoviedata();
+  @Cron('0 10 0 * * *', { timeZone: 'Asia/Seoul' })
+  handleDailyMovieSync() {
+    void this.runMovieSync();
+  }
+
+  @Cron('0 0 1,3,7 * * *', { timeZone: 'Asia/Seoul' })
+  handleMovieSyncRetry() {
+    void this.runMovieSync();
+  }
+
+  private async runMovieSync() {
+    await this.movieService.fetchMoviedata();
   }
 }

--- a/apps/movie/src/movie-read.service.ts
+++ b/apps/movie/src/movie-read.service.ts
@@ -39,18 +39,12 @@ export class MovieReadService {
       throw new BadRequestException('Invalid date provided');
     }
 
-    const movieList = await this.prisma.movie.findMany({
-      where: {
-        updatedAt: { gte: new Date(dateObject) },
-        rank: { gt: 0 },
-      },
-      include: MOVIE_INCLUDE,
-      take: 10,
-      orderBy: [{ rank: 'asc' }],
-    });
+    const movieList = await this.findTodayRankedMovies(dateObject);
+    const fallbackList =
+      movieList.length > 0 ? movieList : await this.findRecentRankedMovies();
 
     return {
-      MovieData: movieList.map((movieData) =>
+      MovieData: fallbackList.map((movieData) =>
         convertMovieDataWithCounts({
           ...movieData,
           _count: {
@@ -60,6 +54,31 @@ export class MovieReadService {
         }),
       ),
     };
+  }
+
+  private findTodayRankedMovies(dateObject: Date) {
+    return this.prisma.movie.findMany({
+      where: {
+        updatedAt: { gte: new Date(dateObject) },
+        rank: { gt: 0 },
+      },
+      include: MOVIE_INCLUDE,
+      take: 10,
+      orderBy: [{ rank: 'asc' }],
+    });
+  }
+
+  private async findRecentRankedMovies() {
+    const movies = await this.prisma.movie.findMany({
+      where: { rank: { gt: 0 } },
+      include: MOVIE_INCLUDE,
+      take: 30,
+      orderBy: [{ updatedAt: 'desc' }],
+    });
+
+    return movies
+      .sort((a, b) => Number(a.rank ?? 999) - Number(b.rank ?? 999))
+      .slice(0, 10);
   }
 
   async recommendMovies(_movieCd: number): Promise<any> {


### PR DESCRIPTION
## Summary
영화 동기화가 실패하거나 KOFIC 데이터가 지연되어도 홈 영화 리스트가 비지 않도록 백엔드 fallback과 cron 재시도를 추가합니다.

## 원인
`/movie` 목록 API가 오늘 00:00 이후 `updatedAt`이 찍힌 `rank > 0` 영화만 반환하고 있었습니다. 00:10 동기화가 실패하면 오전 시간대에도 당일 데이터가 없어 빈 배열이 내려갈 수 있었습니다.

## 변경
- 오늘 rank 영화가 없으면 최근 업데이트된 `rank > 0` 영화 30개 중 rank 순 10개를 fallback 반환
- 영화 동기화 cron을 KST 기준 00:10 기본 실행 + 01:00/03:00/07:00 재시도로 보강
- cron timezone을 `Asia/Seoul`로 명시

## Test plan
- [x] `pnpm exec prisma generate --schema prisma/mysql.schema.prisma`
- [x] `pnpm exec tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/cron/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)