### PR TITLE
🐛 영화 순위 표시 여부 응답 추가

### DIFF
--- a/apps/api-gateway/src/movie/decorator/get-movie-spec-decorator.ts
+++ b/apps/api-gateway/src/movie/decorator/get-movie-spec-decorator.ts
@@ -14,6 +14,7 @@ export function GetMovieSpecDecorator(summary: string, description: string) {
           title: { type: 'string', example: 'test' },
           audience: { type: 'number', example: 1000 },
           rank: { type: 'number', example: 1 },
+          isRanked: { type: 'boolean', example: true },
           movieCd: { type: 'number', example: 100001 },
           createdAt: { type: 'string', example: '2021-01-01T00:00:00Z' },
           updatedAt: { type: 'string', example: '2021-01-01T00:00:00Z' },

--- a/apps/movie/src/movie.formatter.ts
+++ b/apps/movie/src/movie.formatter.ts
@@ -43,6 +43,7 @@ export function convertKobisMovieData(unknown: any): KobisMovie {
 export function convertMovieDataWithCounts(
   movieData: any,
 ): Omit<MovieData, 'vector'> {
+  const rank = Number(movieData.rank) || 0;
   const scoreSum =
     movieData.movieScores?.reduce((sum, score) => sum + score.score, 0) || 0;
   const scoreCount = movieData._count?.movieScores || 0;
@@ -52,7 +53,8 @@ export function convertMovieDataWithCounts(
   return {
     title: movieData.title ?? '',
     audience: Number(movieData.audience) ?? 0,
-    rank: Number(movieData.rank) ?? 0,
+    rank,
+    isRanked: rank > 0,
     createdAt: movieData.createdAt ?? new Date(0),
     updatedAt: movieData.updatedAt ?? new Date(0),
     id: Number(movieData.id) ?? 0,

--- a/libs/common/src/protobuf/movie.ts
+++ b/libs/common/src/protobuf/movie.ts
@@ -55,6 +55,7 @@ export interface MovieData {
   commentCount: number;
   scoreCount: number;
   averageScore: number; // 추가된 필드
+  isRanked: boolean;
 }
 
 export interface MovieVod {

--- a/proto/movie.proto
+++ b/proto/movie.proto
@@ -63,6 +63,7 @@ message MovieData {
   int32 commentCount = 17;
   int32 scoreCount = 18;
   double averageScore = 19; // 추가된 필드
+  bool isRanked = 20;
 }
 
 message MovieVod {


### PR DESCRIPTION
## Summary
박스오피스 TOP10이 아닌 영화도 rank=0으로 내려와 상세 화면에 순위가 노출될 수 있어, 명시적인 순위 노출 여부 값을 추가합니다.

## 원인
감독 필모그래피로 들어간 영화는 TOP10 랭킹 대상이 아니지만 rank 기본값이 0으로 유지되어 프론트에서 구분할 명시 필드가 없었습니다.

## 변경
- MovieData proto에 `isRanked` 추가
- movie formatter에서 `rank > 0` 기준으로 `isRanked` 계산
- API Gateway Swagger 응답 스키마에 `isRanked` 추가

## Test plan
- [x] `make generate_grpc_code`
- [x] `pnpm prisma generate --schema prisma/mysql.schema.prisma`
- [x] `pnpm exec tsc -p apps/movie/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)