### PR TITLE
✨ 사용자 활동·가입 통계 API 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,7 @@ MATCH_GRPC_URL=0.0.0.0:50059
 # 예) ALLOWED_ORIGINS=https://drunkenmovie.shop,https://www.drunkenmovie.shop
 # 개발환경: ALLOWED_ORIGINS=http://localhost:3000
 ALLOWED_ORIGINS=
+
+# 운영 통계 API 접근 허용 사용자 ID (콤마 구분)
+# 예) ANALYTICS_ADMIN_USER_IDS=1,4
+ANALYTICS_ADMIN_USER_IDS=

--- a/apps/api-gateway/src/analytics/analytics-admin.guard.ts
+++ b/apps/api-gateway/src/analytics/analytics-admin.guard.ts
@@ -1,0 +1,23 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+
+@Injectable()
+export class AnalyticsAdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const userId = Number(request.user?.userId);
+    const adminIds = (process.env.ANALYTICS_ADMIN_USER_IDS ?? '')
+      .split(',')
+      .map((value) => Number(value.trim()))
+      .filter(Number.isInteger);
+
+    if (!userId || !adminIds.includes(userId)) {
+      throw new ForbiddenException('통계 접근 권한이 없습니다.');
+    }
+    return true;
+  }
+}

--- a/apps/api-gateway/src/analytics/analytics.controller.ts
+++ b/apps/api-gateway/src/analytics/analytics.controller.ts
@@ -1,0 +1,15 @@
+import { JwtAuthGuard } from '@app/common/guards/jwtauth/jwtauth.guard';
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { AnalyticsAdminGuard } from './analytics-admin.guard';
+import { AnalyticsService } from './analytics.service';
+
+@Controller('analytics')
+@UseGuards(JwtAuthGuard, AnalyticsAdminGuard)
+export class AnalyticsController {
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  @Get('summary')
+  getSummary() {
+    return this.analyticsService.getSummary();
+  }
+}

--- a/apps/api-gateway/src/analytics/analytics.module.ts
+++ b/apps/api-gateway/src/analytics/analytics.module.ts
@@ -1,0 +1,13 @@
+import { PrismaModule } from '@app/prisma';
+import { Module } from '@nestjs/common';
+import { AnalyticsAdminGuard } from './analytics-admin.guard';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService, AnalyticsAdminGuard],
+  exports: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/apps/api-gateway/src/analytics/analytics.service.ts
+++ b/apps/api-gateway/src/analytics/analytics.service.ts
@@ -1,0 +1,103 @@
+import { MySQLPrismaService } from '@app/prisma';
+import { Injectable } from '@nestjs/common';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const KST_OFFSET_MS = 9 * HOUR_MS;
+
+function getKstMonthStart(date: Date, monthOffset = 0) {
+  const kst = new Date(date.getTime() + KST_OFFSET_MS);
+  return new Date(
+    Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth() + monthOffset, 1) -
+      KST_OFFSET_MS,
+  );
+}
+
+function getKstDayStart(date: Date) {
+  const kst = new Date(date.getTime() + KST_OFFSET_MS);
+  return new Date(
+    Date.UTC(kst.getUTCFullYear(), kst.getUTCMonth(), kst.getUTCDate()) -
+      KST_OFFSET_MS,
+  );
+}
+
+function getKstMonthLabel(date: Date) {
+  const kst = new Date(date.getTime() + KST_OFFSET_MS);
+  return `${kst.getUTCFullYear()}-${String(kst.getUTCMonth() + 1).padStart(
+    2,
+    '0',
+  )}`;
+}
+
+@Injectable()
+export class AnalyticsService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async touchUser(userId: number) {
+    const threshold = new Date(Date.now() - HOUR_MS);
+    await this.prisma.user.updateMany({
+      where: {
+        id: userId,
+        deletedAt: null,
+        OR: [{ lastActiveAt: null }, { lastActiveAt: { lt: threshold } }],
+      },
+      data: { lastActiveAt: new Date() },
+    });
+  }
+
+  async getSummary() {
+    const now = new Date();
+    const todayStart = getKstDayStart(now);
+    const monthStart = getKstMonthStart(now);
+    const seriesStart = getKstMonthStart(now, -5);
+    const [
+      totalUsers,
+      signupsThisMonth,
+      activeToday,
+      active7d,
+      active30d,
+      signups,
+    ] = await Promise.all([
+      this.prisma.user.count({ where: { deletedAt: null } }),
+      this.prisma.user.count({
+        where: { deletedAt: null, createdAt: { gte: monthStart } },
+      }),
+      this.countActiveSince(todayStart),
+      this.countActiveSince(new Date(now.getTime() - 7 * DAY_MS)),
+      this.countActiveSince(new Date(now.getTime() - 30 * DAY_MS)),
+      this.prisma.user.findMany({
+        where: { deletedAt: null, createdAt: { gte: seriesStart } },
+        select: { createdAt: true },
+      }),
+    ]);
+
+    const monthlySignups = Array.from({ length: 6 }, (_, index) => {
+      const month = getKstMonthStart(now, index - 5);
+      return { month: getKstMonthLabel(month), count: 0 };
+    });
+    const monthCounts = new Map(monthlySignups.map((item) => [item.month, 0]));
+    signups.forEach(({ createdAt }) => {
+      const label = getKstMonthLabel(createdAt);
+      monthCounts.set(label, (monthCounts.get(label) ?? 0) + 1);
+    });
+    monthlySignups.forEach((item) => {
+      item.count = monthCounts.get(item.month) ?? 0;
+    });
+
+    return {
+      generatedAt: now.toISOString(),
+      totalUsers,
+      signupsThisMonth,
+      activeToday,
+      active7d,
+      active30d,
+      monthlySignups,
+    };
+  }
+
+  private countActiveSince(since: Date) {
+    return this.prisma.user.count({
+      where: { deletedAt: null, lastActiveAt: { gte: since } },
+    });
+  }
+}

--- a/apps/api-gateway/src/analytics/user-activity.interceptor.ts
+++ b/apps/api-gateway/src/analytics/user-activity.interceptor.ts
@@ -1,0 +1,29 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, tap } from 'rxjs';
+import { AnalyticsService } from './analytics.service';
+
+@Injectable()
+export class UserActivityInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(UserActivityInterceptor.name);
+
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest();
+    const userId = Number(request.user?.userId);
+    return next.handle().pipe(
+      tap(() => {
+        if (!userId) return;
+        void this.analyticsService.touchUser(userId).catch((error) => {
+          this.logger.warn(`Failed to update activity for user ${userId}`, error);
+        });
+      }),
+    );
+  }
+}

--- a/apps/api-gateway/src/app.module.ts
+++ b/apps/api-gateway/src/app.module.ts
@@ -10,6 +10,9 @@ import { ArticleModule } from './article/article.module';
 import { MatchModule } from './match/match.module';
 import { ChatModule } from './chat/chat.module';
 import { NotificationModule } from './notification/notification.module';
+import { AnalyticsModule } from './analytics/analytics.module';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { UserActivityInterceptor } from './analytics/user-activity.interceptor';
 
 @Module({
   imports: [
@@ -30,8 +33,12 @@ import { NotificationModule } from './notification/notification.module';
     MatchModule,
     ChatModule,
     NotificationModule,
+    AnalyticsModule,
   ],
   controllers: [],
-  providers: [JwtStrategy],
+  providers: [
+    JwtStrategy,
+    { provide: APP_INTERCEPTOR, useClass: UserActivityInterceptor },
+  ],
 })
 export class AppModule {}

--- a/apps/auth/src/auth-user.mapper.ts
+++ b/apps/auth/src/auth-user.mapper.ts
@@ -1,0 +1,13 @@
+import { User } from '@app/common/protobuf';
+
+export function toAuthUser(user: any): User {
+  const { password: _, ...safeUser } = user;
+  return {
+    ...safeUser,
+    nickname: safeUser.nickname ?? '',
+    createdAt: safeUser.createdAt.toISOString(),
+    updatedAt: safeUser.updatedAt.toISOString(),
+    deletedAt: safeUser.deletedAt ? safeUser.deletedAt.toISOString() : null,
+    gender: safeUser.gender ?? '',
+  } as User;
+}

--- a/apps/auth/src/auth.service.ts
+++ b/apps/auth/src/auth.service.ts
@@ -7,6 +7,7 @@ import { randomBytes } from 'crypto';
 import { compare, hash } from 'bcryptjs';
 import Redis from 'ioredis';
 import { EmailService } from './email.service';
+import { toAuthUser } from './auth-user.mapper';
 
 const VERIFY_TTL = 5 * 60;       // 5분 (초)
 const RESET_TTL  = 60 * 60;      // 1시간 (초)
@@ -31,13 +32,11 @@ export class AuthService {
 
     const isMatch = await compare(password, user.password);
     if (isMatch) {
-      const { password: _, ...result } = user;
-      return {
-        ...result,
-        createdAt: result.createdAt.toISOString(),
-        updatedAt: result.updatedAt.toISOString(),
-        deletedAt: result.deletedAt ? result.deletedAt.toISOString() : null,
-      };
+      const activeUser = await this.mysqlPrismaService.user.update({
+        where: { id: user.id },
+        data: { lastActiveAt: new Date() },
+      });
+      return toAuthUser(activeUser);
     }
     return null;
   }
@@ -59,27 +58,16 @@ export class AuthService {
           password: hashedPassword,
           nickname: null,
           image: DEFAULT_PROFILE_IMAGE_URL,
+          lastActiveAt: new Date(),
         },
       });
-      return {
-        id: newUser.id,
-        email: newUser.email,
-        nickname: newUser.nickname ?? '',
-        image: newUser.image,
-        createdAt: newUser.createdAt.toISOString(),
-        updatedAt: newUser.updatedAt.toISOString(),
-        deletedAt: newUser.deletedAt ? newUser.deletedAt.toISOString() : null,
-        gender: newUser.gender ?? '',
-      } as User;
+      return toAuthUser(newUser);
     }
-    return {
-      ...user,
-      nickname: user.nickname ?? '',
-      createdAt: user.createdAt.toISOString(),
-      updatedAt: user.updatedAt.toISOString(),
-      deletedAt: user.deletedAt ? user.deletedAt.toISOString() : null,
-      gender: user.gender ?? '',
-    };
+    const activeUser = await this.mysqlPrismaService.user.update({
+      where: { id: user.id },
+      data: { lastActiveAt: new Date() },
+    });
+    return toAuthUser(activeUser);
   }
 
   async validateEmail(email: string): Promise<ValidationResponse> {

--- a/prisma/migrations/20260712000000_add_user_last_active_at/migration.sql
+++ b/prisma/migrations/20260712000000_add_user_last_active_at/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `User`
+  ADD COLUMN `lastActiveAt` DATETIME(6) NULL;
+
+CREATE INDEX `User_lastActiveAt_idx` ON `User`(`lastActiveAt`);

--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -72,6 +72,7 @@ model User {
   createdAt        DateTime           @default(now()) @db.DateTime(6)
   updatedAt        DateTime           @default(now()) @db.DateTime(6)
   deletedAt        DateTime?          @db.DateTime(6)
+  lastActiveAt     DateTime?          @db.DateTime(6)
   provider         String             @default("credentials") @db.VarChar(45)
   image            String?            @db.LongText
   marketing_agreed Boolean            @default(false)
@@ -86,6 +87,8 @@ model User {
   ChatRoomMember   ChatRoomMember[]
   ChatMessage      ChatMessage[]
   Notification     Notification[]
+
+  @@index([lastActiveAt], map: "User_lastActiveAt_idx")
 }
 
 


### PR DESCRIPTION
## Summary
- 사용자 `lastActiveAt` 컬럼과 인덱스 추가
- 로그인 및 성공한 인증 API 요청을 활동으로 집계
- 관리자 전용 `GET /analytics/summary` 추가
- 월 가입자, 오늘/7일/30일 활성 사용자, 최근 6개월 가입 추이 제공

## 운영 설정
- `.env.production`에 `ANALYTICS_ADMIN_USER_IDS=<관리자 userId>` 필요
- 배포 workflow의 `prisma migrate deploy`로 마이그레이션 자동 적용

## Test plan
- [x] `pnpm exec tsc -p apps/auth/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] `git diff --check`
- [x] 신규/수정 TypeScript 파일 200줄 상한 확인
- [ ] master 머지 후 GitHub Actions 및 마이그레이션 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)