### PR TITLE
🐛 기존 댓글 작성자 기본 아바타 보완

### DIFF
--- a/apps/reply/src/reply.mapper.spec.ts
+++ b/apps/reply/src/reply.mapper.spec.ts
@@ -1,0 +1,24 @@
+import { DEFAULT_PROFILE_IMAGE_URL } from '@app/common/constants/profile';
+import { toReply } from './reply.mapper';
+
+describe('toReply', () => {
+  it('uses the default profile image for legacy users without an image', () => {
+    const now = new Date('2026-07-17T00:00:00.000Z');
+    const result = toReply({
+      id: 1,
+      comment: '댓글',
+      parentId: null,
+      createdAt: now,
+      updatedAt: now,
+      replies: [],
+      User: {
+        id: 4,
+        email: 'user@example.com',
+        nickname: '영화조아용',
+        image: null,
+      },
+    });
+
+    expect(result.avatar).toBe(DEFAULT_PROFILE_IMAGE_URL);
+  });
+});

--- a/apps/reply/src/reply.mapper.ts
+++ b/apps/reply/src/reply.mapper.ts
@@ -1,4 +1,5 @@
 import { Reply } from '@app/common/protobuf';
+import { DEFAULT_PROFILE_IMAGE_URL } from '@app/common/constants/profile';
 
 export function toReply(reply: any): Reply {
   return {
@@ -6,7 +7,7 @@ export function toReply(reply: any): Reply {
     comment: reply.comment,
     email: reply.User.email,
     nickname: reply.User.nickname,
-    avatar: reply.User.image ?? '',
+    avatar: reply.User.image?.trim() || DEFAULT_PROFILE_IMAGE_URL,
     userId: reply.User.id,
     createdAt: reply.createdAt.toISOString(),
     updatedAt: reply.updatedAt.toISOString(),


### PR DESCRIPTION
## Summary
- 이미지가 없는 기존 사용자의 영화 댓글에 기본 프로필 이미지를 반환합니다.
- 신규 가입 이전 계정도 아바타가 글자 한 글자로 표시되지 않게 합니다.

## Test plan
- [x] `pnpm exec jest apps/reply/src/reply.service.spec.ts apps/reply/src/reply.mapper.spec.ts --runInBand`
- [x] `pnpm exec tsc -p apps/reply/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 파일 200줄 상한 확인