### PR TITLE
✨ 영화 댓글 반응과 상태 관리 추가

### DIFF
--- a/apps/api-gateway/src/reply/reply.controller.ts
+++ b/apps/api-gateway/src/reply/reply.controller.ts
@@ -1,5 +1,6 @@
 import { CreateReplyDto, UpdateReplyDto } from '@app/common/protobuf';
 import { JwtAuthGuard } from '@app/common/guards/jwtauth/jwtauth.guard';
+import { OptionalJwtAuthGuard } from '@app/common/guards/jwtauth/optional-jwt-auth.guard';
 import { RateLimitGuard } from '@app/common/guards/rateLimit/rate-limit.guard';
 import {
   Body,
@@ -25,6 +26,7 @@ export class ReplyController {
   constructor(private readonly replyService: ReplyService) {}
   @GetReplySpecDecorator('댓글 조회 API', '댓글 조회')
   @Get('/')
+  @UseGuards(OptionalJwtAuthGuard)
   async get(
     @Req() req,
     @Query('movieId') movieId: number,
@@ -34,6 +36,7 @@ export class ReplyController {
       const getRepliesObservable = this.replyService.getReplies({
         movieId: movieId,
         page: page,
+        userId: req.user?.userId,
       });
       const data = await firstValueFrom(getRepliesObservable);
       return data;
@@ -82,6 +85,21 @@ export class ReplyController {
         message: error.details,
       });
     }
+  }
+  @Post('/:replyId/reaction')
+  @UseGuards(JwtAuthGuard, RateLimitGuard)
+  async react(
+    @Req() req,
+    @Param('replyId') replyId: number,
+    @Body('reaction') reaction: string,
+  ) {
+    return firstValueFrom(
+      this.replyService.react({
+        commentId: Number(replyId),
+        userId: req.user.userId,
+        reaction,
+      }),
+    );
   }
   @Post('/:replyId')
   @DeleteReplySpecDecorator('댓글 삭제 API', '댓글 삭제')

--- a/apps/api-gateway/src/reply/reply.service.ts
+++ b/apps/api-gateway/src/reply/reply.service.ts
@@ -5,6 +5,7 @@ import {
   REPLY_PACKAGE_NAME,
   REPLY_SERVICE_NAME,
   ReplyServiceClient,
+  ReactReplyDto,
   UpdateReplyDto,
 } from '@app/common/protobuf';
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
@@ -33,5 +34,8 @@ export class ReplyService implements OnModuleInit {
   }
   getReplies(getRepliesDto: GetReplyDto) {
     return this.replyService.getReply(getRepliesDto);
+  }
+  react(reactReplyDto: ReactReplyDto) {
+    return this.replyService.reactReply(reactReplyDto);
   }
 }

--- a/apps/reply/src/reply-command.service.ts
+++ b/apps/reply/src/reply-command.service.ts
@@ -1,0 +1,92 @@
+import {
+  CreateReplyDto,
+  DeleteReplyDto,
+  Reply,
+  UpdateReplyDto,
+} from '@app/common/protobuf';
+import {
+  InvalidArguementException,
+  NotFoundException,
+} from '@app/common/filters/rpcexception/rpc-exception';
+import { MySQLPrismaService } from '@app/prisma';
+import { ForbiddenException } from '@nestjs/common';
+import { toReply } from './reply.mapper';
+
+export class ReplyCommandService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async create(dto: CreateReplyDto): Promise<Reply> {
+    const { comment, userId, movieId, parentId } = dto;
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user)
+      throw new NotFoundException('해당하는 유저가 존재하지 않습니다.');
+    await this.prisma.movie.findUniqueOrThrow({ where: { movieCd: movieId } });
+
+    if (parentId) {
+      const parent = await this.prisma.comment.findUnique({
+        where: { id: parentId },
+      });
+      if (!parent || parent.deletedAt || parent.movieId !== movieId) {
+        throw new NotFoundException('답글을 작성할 댓글이 존재하지 않습니다.');
+      }
+      if (parent.parentId) {
+        throw new InvalidArguementException(
+          '답글에는 다시 답글을 작성할 수 없습니다.',
+        );
+      }
+    }
+
+    const reply = await this.prisma.comment.create({
+      data: { userno: userId, comment, movieId, parentId },
+    });
+    return toReply(
+      { ...reply, User: user, reactions: [], replies: [] },
+      userId,
+    );
+  }
+
+  async update(dto: UpdateReplyDto): Promise<Reply> {
+    const existing = await this.findOwned(dto.commentId, dto.userId);
+    const reply = await this.prisma.comment.update({
+      where: { id: dto.commentId },
+      data: { comment: dto.comment, isEdited: true, updatedAt: new Date() },
+    });
+    const user = await this.findUser(existing.userno);
+    return toReply(
+      { ...reply, User: user, reactions: [], replies: [] },
+      dto.userId,
+    );
+  }
+
+  async delete(dto: DeleteReplyDto): Promise<Reply> {
+    const existing = await this.findOwned(dto.commentId, dto.userId);
+    const reply = await this.prisma.comment.update({
+      where: { id: dto.commentId },
+      data: { deletedAt: new Date() },
+    });
+    const user = await this.findUser(existing.userno);
+    return toReply(
+      { ...reply, User: user, reactions: [], replies: [] },
+      dto.userId,
+    );
+  }
+
+  private async findOwned(commentId: number, userId: number) {
+    const reply = await this.prisma.comment.findUnique({
+      where: { id: commentId },
+    });
+    if (!reply || reply.deletedAt)
+      throw new NotFoundException('댓글이 존재하지 않습니다.');
+    if (reply.userno !== userId) {
+      throw new ForbiddenException('자신의 댓글만 변경할 수 있습니다.');
+    }
+    return reply;
+  }
+
+  private async findUser(userId: number) {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user)
+      throw new NotFoundException('해당하는 유저가 존재하지 않습니다.');
+    return user;
+  }
+}

--- a/apps/reply/src/reply-query.service.ts
+++ b/apps/reply/src/reply-query.service.ts
@@ -1,0 +1,49 @@
+import { GetReplyDto, Reply } from '@app/common/protobuf';
+import { MySQLPrismaService } from '@app/prisma';
+import { Logger } from '@nestjs/common';
+import { toReply } from './reply.mapper';
+
+export class ReplyQueryService {
+  private readonly logger = new Logger(ReplyQueryService.name);
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async getReplies(
+    dto: GetReplyDto,
+  ): Promise<{ replies: Reply[]; hasNext: boolean }> {
+    const { movieId, page, userId } = dto;
+    const take = 10;
+    const skip = (page - 1) * take;
+    const where = {
+      movieId,
+      parentId: null,
+      OR: [{ deletedAt: null }, { replies: { some: { deletedAt: null } } }],
+    };
+    const reactionSelect = { userno: true, type: true } as const;
+    const [replies, totalCount] = await Promise.all([
+      this.prisma.comment.findMany({
+        where,
+        include: {
+          User: true,
+          reactions: { select: reactionSelect },
+          replies: {
+            where: { deletedAt: null },
+            include: {
+              User: true,
+              reactions: { select: reactionSelect },
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take,
+      }),
+      this.prisma.comment.count({ where }),
+    ]);
+    this.logger.debug(`getReplies movieId=${movieId} count=${replies.length}`);
+    return {
+      replies: replies.map((reply) => toReply(reply, userId)),
+      hasNext: skip + take < totalCount,
+    };
+  }
+}

--- a/apps/reply/src/reply-reaction.service.ts
+++ b/apps/reply/src/reply-reaction.service.ts
@@ -1,0 +1,59 @@
+import { ReactReplyDto, ReplyReactionResult } from '@app/common/protobuf';
+import {
+  InvalidArguementException,
+  NotFoundException,
+} from '@app/common/filters/rpcexception/rpc-exception';
+import { MySQLPrismaService } from '@app/prisma';
+
+type Reaction = 'like' | 'dislike';
+
+export class ReplyReactionService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async react(dto: ReactReplyDto): Promise<ReplyReactionResult> {
+    const reaction = this.validateReaction(dto.reaction);
+    const comment = await this.prisma.comment.findUnique({
+      where: { id: dto.commentId },
+    });
+    if (!comment || comment.deletedAt) {
+      throw new NotFoundException('댓글이 존재하지 않습니다.');
+    }
+
+    const existing = await this.prisma.commentReaction.findUnique({
+      where: {
+        commentId_userno: { commentId: dto.commentId, userno: dto.userId },
+      },
+    });
+    let selected: Reaction | '' = reaction;
+    if (!existing) {
+      await this.prisma.commentReaction.create({
+        data: { commentId: dto.commentId, userno: dto.userId, type: reaction },
+      });
+    } else if (existing.type === reaction) {
+      await this.prisma.commentReaction.delete({ where: { id: existing.id } });
+      selected = '';
+    } else {
+      await this.prisma.commentReaction.update({
+        where: { id: existing.id },
+        data: { type: reaction },
+      });
+    }
+
+    const [likeCount, dislikeCount] = await Promise.all([
+      this.count(dto.commentId, 'like'),
+      this.count(dto.commentId, 'dislike'),
+    ]);
+    return { likeCount, dislikeCount, reaction: selected };
+  }
+
+  private count(commentId: number, type: Reaction) {
+    return this.prisma.commentReaction.count({ where: { commentId, type } });
+  }
+
+  private validateReaction(value: string): Reaction {
+    if (value !== 'like' && value !== 'dislike') {
+      throw new InvalidArguementException('올바르지 않은 반응입니다.');
+    }
+    return value;
+  }
+}

--- a/apps/reply/src/reply.controller.ts
+++ b/apps/reply/src/reply.controller.ts
@@ -4,6 +4,7 @@ import {
   GetReplyDto,
   ReplyServiceController,
   ReplyServiceControllerMethods,
+  ReactReplyDto,
   UpdateReplyDto,
 } from '@app/common/protobuf';
 import { Controller } from '@nestjs/common';
@@ -28,5 +29,9 @@ export class ReplyController implements ReplyServiceController {
 
   async getReply(getReplyDto: GetReplyDto) {
     return await this.replyService.getReplies(getReplyDto);
+  }
+
+  async reactReply(reactReplyDto: ReactReplyDto) {
+    return await this.replyService.react(reactReplyDto);
   }
 }

--- a/apps/reply/src/reply.mapper.spec.ts
+++ b/apps/reply/src/reply.mapper.spec.ts
@@ -21,4 +21,81 @@ describe('toReply', () => {
 
     expect(result.avatar).toBe(DEFAULT_PROFILE_IMAGE_URL);
   });
+
+  it('hides deleted content and preserves its active child replies', () => {
+    const now = new Date('2026-07-17T00:00:00.000Z');
+    const user = {
+      id: 4,
+      email: 'user@example.com',
+      nickname: '영화조아용',
+      image: null,
+    };
+    const result = toReply({
+      id: 1,
+      comment: '삭제 전 내용',
+      deletedAt: now,
+      isEdited: false,
+      parentId: null,
+      createdAt: now,
+      updatedAt: now,
+      reactions: [],
+      replies: [
+        {
+          id: 2,
+          comment: '남아 있는 대댓글',
+          deletedAt: null,
+          isEdited: false,
+          parentId: 1,
+          createdAt: now,
+          updatedAt: now,
+          reactions: [],
+          replies: [],
+          User: user,
+        },
+      ],
+      User: user,
+    });
+
+    expect(result).toMatchObject({
+      comment: '삭제된 댓글입니다.',
+      isDeleted: true,
+      replies: [expect.objectContaining({ comment: '남아 있는 대댓글' })],
+    });
+  });
+
+  it('maps edit and reaction state for the current user', () => {
+    const now = new Date('2026-07-17T00:00:00.000Z');
+    const result = (toReply as any)(
+      {
+        id: 1,
+        comment: '수정된 댓글',
+        deletedAt: null,
+        isEdited: true,
+        parentId: null,
+        createdAt: now,
+        updatedAt: now,
+        replies: [],
+        reactions: [
+          { userno: 4, type: 'like' },
+          { userno: 5, type: 'like' },
+          { userno: 6, type: 'dislike' },
+        ],
+        User: {
+          id: 4,
+          email: 'user@example.com',
+          nickname: '영화조아용',
+          image: null,
+        },
+      },
+      4,
+    );
+
+    expect(result).toMatchObject({
+      isEdited: true,
+      isDeleted: false,
+      likeCount: 2,
+      dislikeCount: 1,
+      userReaction: 'like',
+    });
+  });
 });

--- a/apps/reply/src/reply.mapper.ts
+++ b/apps/reply/src/reply.mapper.ts
@@ -1,10 +1,12 @@
 import { Reply } from '@app/common/protobuf';
 import { DEFAULT_PROFILE_IMAGE_URL } from '@app/common/constants/profile';
 
-export function toReply(reply: any): Reply {
+export function toReply(reply: any, userId?: number): Reply {
+  const reactions = reply.reactions ?? [];
+  const isDeleted = Boolean(reply.deletedAt);
   return {
     replyId: reply.id,
-    comment: reply.comment,
+    comment: isDeleted ? '삭제된 댓글입니다.' : reply.comment,
     email: reply.User.email,
     nickname: reply.User.nickname,
     avatar: reply.User.image?.trim() || DEFAULT_PROFILE_IMAGE_URL,
@@ -12,6 +14,11 @@ export function toReply(reply: any): Reply {
     createdAt: reply.createdAt.toISOString(),
     updatedAt: reply.updatedAt.toISOString(),
     parentId: reply.parentId ?? undefined,
-    replies: (reply.replies ?? []).map(toReply),
+    replies: (reply.replies ?? []).map((child) => toReply(child, userId)),
+    likeCount: reactions.filter((item) => item.type === 'like').length,
+    dislikeCount: reactions.filter((item) => item.type === 'dislike').length,
+    userReaction: reactions.find((item) => item.userno === userId)?.type ?? '',
+    isEdited: Boolean(reply.isEdited),
+    isDeleted,
   };
 }

--- a/apps/reply/src/reply.module.ts
+++ b/apps/reply/src/reply.module.ts
@@ -2,10 +2,9 @@ import { Module } from '@nestjs/common';
 import { ReplyController } from './reply.controller';
 import { ReplyService } from './reply.service';
 import { PrismaModule } from '@app/prisma';
-import { UtilsModule } from '@app/utils';
 
 @Module({
-  imports: [PrismaModule, UtilsModule],
+  imports: [PrismaModule],
   controllers: [ReplyController],
   providers: [ReplyService],
 })

--- a/apps/reply/src/reply.service.spec.ts
+++ b/apps/reply/src/reply.service.spec.ts
@@ -15,17 +15,69 @@ describe('ReplyService movie comment replies', () => {
       findMany: jest.fn(),
       count: jest.fn(),
       create: jest.fn(),
+      update: jest.fn(),
+    },
+    commentReaction: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
     },
   };
-  const service = new ReplyService(
-    prisma as never,
-    { dateToTimestamp: jest.fn() } as never,
-  );
+  const service = new ReplyService(prisma as never);
 
   beforeEach(() => {
     jest.clearAllMocks();
     prisma.user.findUnique.mockResolvedValue(user);
     prisma.movie.findUniqueOrThrow.mockResolvedValue({ movieCd: 20233219 });
+  });
+
+  it('toggles the same reaction off and returns updated counts', async () => {
+    prisma.comment.findUnique.mockResolvedValue({ id: 10, deletedAt: null });
+    prisma.commentReaction.findUnique.mockResolvedValue({
+      id: 3,
+      type: 'like',
+    });
+    prisma.commentReaction.delete.mockResolvedValue({ id: 3 });
+    prisma.commentReaction.count
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(1);
+
+    const result = await (service as any).react({
+      userId: 4,
+      commentId: 10,
+      reaction: 'like',
+    });
+
+    expect(prisma.commentReaction.delete).toHaveBeenCalledWith({
+      where: { id: 3 },
+    });
+    expect(result).toEqual({ likeCount: 2, dislikeCount: 1, reaction: '' });
+  });
+
+  it('switches an existing reaction to the opposite type', async () => {
+    prisma.comment.findUnique.mockResolvedValue({ id: 10, deletedAt: null });
+    prisma.commentReaction.findUnique.mockResolvedValue({
+      id: 3,
+      type: 'like',
+    });
+    prisma.commentReaction.update.mockResolvedValue({ id: 3, type: 'dislike' });
+    prisma.commentReaction.count
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(3);
+
+    const result = await (service as any).react({
+      userId: 4,
+      commentId: 10,
+      reaction: 'dislike',
+    });
+
+    expect(prisma.commentReaction.update).toHaveBeenCalledWith({
+      where: { id: 3 },
+      data: { type: 'dislike' },
+    });
+    expect(result).toEqual({ likeCount: 1, dislikeCount: 3, reaction: 'dislike' });
   });
 
   it('creates a one-level reply under a comment from the same movie', async () => {
@@ -85,12 +137,42 @@ describe('ReplyService movie comment replies', () => {
 
     expect(prisma.comment.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { movieId: 20233219, deletedAt: null, parentId: null },
+        where: expect.objectContaining({
+          movieId: 20233219,
+          parentId: null,
+          OR: expect.any(Array),
+        }),
       }),
     );
     expect(result.replies[0]).toMatchObject({
       avatar: user.image,
       replies: [expect.objectContaining({ parentId: 10, avatar: user.image })],
     });
+  });
+
+  it('marks an updated comment as edited', async () => {
+    prisma.comment.findUnique.mockResolvedValue({ id: 10, userno: 4 });
+    prisma.comment.update.mockResolvedValue({
+      id: 10,
+      userno: 4,
+      comment: '수정한 댓글',
+      parentId: null,
+      isEdited: true,
+      deletedAt: null,
+      createdAt: new Date('2026-07-17T00:00:00Z'),
+      updatedAt: new Date('2026-07-17T00:01:00Z'),
+    });
+
+    const result = await service.update({
+      userId: 4,
+      commentId: 10,
+      comment: '수정한 댓글',
+    } as never);
+
+    expect(prisma.comment.update).toHaveBeenCalledWith({
+      where: { id: 10 },
+      data: expect.objectContaining({ isEdited: true }),
+    });
+    expect((result as any).isEdited).toBe(true);
   });
 });

--- a/apps/reply/src/reply.service.ts
+++ b/apps/reply/src/reply.service.ts
@@ -1,189 +1,47 @@
 import {
   CreateReplyDto,
-  Reply,
-  UpdateReplyDto,
   DeleteReplyDto,
+  GetReplyDto,
+  ReactReplyDto,
+  Reply,
+  ReplyReactionResult,
+  UpdateReplyDto,
 } from '@app/common/protobuf';
-import {
-  InvalidArguementException,
-  NotFoundException,
-} from '@app/common/filters/rpcexception/rpc-exception';
 import { MySQLPrismaService } from '@app/prisma';
-import { UtilsService } from '@app/utils';
-import { Injectable, Logger, ForbiddenException } from '@nestjs/common';
-import { toReply } from './reply.mapper';
+import { Injectable } from '@nestjs/common';
+import { ReplyCommandService } from './reply-command.service';
+import { ReplyQueryService } from './reply-query.service';
+import { ReplyReactionService } from './reply-reaction.service';
 
 @Injectable()
 export class ReplyService {
-  private readonly logger = new Logger(ReplyService.name);
-  constructor(
-    private readonly mysqlPrismaService: MySQLPrismaService,
-    private readonly utilsService: UtilsService,
-  ) {}
+  private readonly commands: ReplyCommandService;
+  private readonly queries: ReplyQueryService;
+  private readonly reactions: ReplyReactionService;
 
-  async create(createReplyDto: CreateReplyDto): Promise<Reply> {
-    const { comment, userId, movieId, parentId } = createReplyDto;
-    const userData = await this.mysqlPrismaService.user.findUnique({
-      where: { id: userId },
-    });
-    if (!userData) {
-      throw new NotFoundException('해당하는 유저가 존재하지 않습니다.');
-    }
-    await this.mysqlPrismaService.movie.findUniqueOrThrow({
-      where: { movieCd: movieId },
-    });
-
-    if (parentId) {
-      const parent = await this.mysqlPrismaService.comment.findUnique({
-        where: { id: parentId },
-      });
-      if (!parent || parent.deletedAt || parent.movieId !== movieId) {
-        throw new NotFoundException('답글을 작성할 댓글이 존재하지 않습니다.');
-      }
-      if (parent.parentId) {
-        throw new InvalidArguementException(
-          '답글에는 다시 답글을 작성할 수 없습니다.',
-        );
-      }
-    }
-
-    const reply = await this.mysqlPrismaService.comment.create({
-      data: {
-        userno: userId,
-        comment: comment,
-        movieId: movieId,
-        parentId,
-      },
-    });
-
-    return toReply({ ...reply, User: userData, replies: [] });
+  constructor(prisma: MySQLPrismaService) {
+    this.commands = new ReplyCommandService(prisma);
+    this.queries = new ReplyQueryService(prisma);
+    this.reactions = new ReplyReactionService(prisma);
   }
 
-  async update(updateReplyDto: UpdateReplyDto): Promise<Reply> {
-    const { commentId, comment, userId } = updateReplyDto;
-
-    // 기존 댓글 조회 및 권한 확인
-    const existingReply = await this.mysqlPrismaService.comment.findUnique({
-      where: { id: commentId },
-    });
-
-    if (!existingReply) {
-      throw new NotFoundException('댓글이 존재하지 않습니다.');
-    }
-
-    if (existingReply.userno !== userId) {
-      throw new ForbiddenException('자신의 댓글만 수정할 수 있습니다.');
-    }
-
-    const reply = await this.mysqlPrismaService.comment.update({
-      where: { id: commentId },
-      data: { comment: comment, updatedAt: new Date() },
-    });
-    const userData = await this.mysqlPrismaService.user.findUnique({
-      where: { id: reply.userno },
-    });
-    if (!userData) {
-      throw new NotFoundException('해당하는 유저가 존재하지 않습니다.');
-    }
-    const createdAt = this.utilsService.dateToTimestamp(
-      reply.createdAt as Date,
-    );
-    const updatedAt = this.utilsService.dateToTimestamp(
-      reply.updatedAt as Date,
-    );
-
-    const replyObject: Reply = {
-      replyId: reply.id,
-      comment: reply.comment,
-      createdAt: createdAt,
-      updatedAt: updatedAt,
-      avatar: userData.image,
-      email: userData.email,
-      nickname: userData.nickname,
-      userId: userData.id,
-      parentId: reply.parentId ?? undefined,
-      replies: [],
-    };
-    return replyObject;
+  create(dto: CreateReplyDto): Promise<Reply> {
+    return this.commands.create(dto);
   }
 
-  async delete(deleteReplyDto: DeleteReplyDto): Promise<Reply> {
-    const { commentId, userId } = deleteReplyDto;
-
-    // 기존 댓글 조회 및 권한 확인
-    const existingReply = await this.mysqlPrismaService.comment.findUnique({
-      where: { id: commentId },
-    });
-
-    if (!existingReply) {
-      throw new NotFoundException('댓글이 존재하지 않습니다.');
-    }
-
-    if (existingReply.userno !== userId) {
-      throw new ForbiddenException('자신의 댓글만 삭제할 수 있습니다.');
-    }
-
-    const reply = await this.mysqlPrismaService.comment.update({
-      where: { id: commentId },
-      data: { deletedAt: new Date() },
-    });
-    const userData = await this.mysqlPrismaService.user.findUnique({
-      where: { id: reply.userno },
-    });
-    if (!userData) {
-      throw new NotFoundException('해당하는 유저가 존재하지 않습니다.');
-    }
-
-    const replyObject: Reply = {
-      replyId: reply.id,
-      comment: reply.comment,
-      createdAt: reply.createdAt.toISOString(),
-      updatedAt: reply.updatedAt.toISOString(),
-      avatar: userData.image,
-      email: userData.email,
-      nickname: userData.nickname,
-      userId: userData.id,
-      parentId: reply.parentId ?? undefined,
-      replies: [],
-    };
-    return replyObject;
+  update(dto: UpdateReplyDto): Promise<Reply> {
+    return this.commands.update(dto);
   }
 
-  async getReplies(getRepliesDto: {
-    movieId: number;
-    page: number;
-  }): Promise<{ replies: Reply[]; hasNext: boolean }> {
-    const { movieId, page } = getRepliesDto;
-    const take = 10;
-    const skip = (page - 1) * take;
+  delete(dto: DeleteReplyDto): Promise<Reply> {
+    return this.commands.delete(dto);
+  }
 
-    const [replies, totalCount] = await Promise.all([
-      this.mysqlPrismaService.comment.findMany({
-        where: { movieId, deletedAt: null, parentId: null },
-        include: {
-          User: true,
-          replies: {
-            where: { deletedAt: null },
-            include: { User: true },
-            orderBy: { createdAt: 'asc' },
-          },
-        },
-        orderBy: { createdAt: 'desc' },
-        skip,
-        take,
-      }),
-      this.mysqlPrismaService.comment.count({
-        where: { movieId, deletedAt: null, parentId: null },
-      }),
-    ]);
-    this.logger.debug(`getReplies movieId=${movieId} count=${replies.length}`);
-    const replyObjects: Reply[] = replies.map(toReply);
+  getReplies(dto: GetReplyDto) {
+    return this.queries.getReplies(dto);
+  }
 
-    const hasNext = skip + take < totalCount;
-
-    return {
-      replies: replyObjects,
-      hasNext,
-    };
+  react(dto: ReactReplyDto): Promise<ReplyReactionResult> {
+    return this.reactions.react(dto);
   }
 }

--- a/libs/common/src/guards/jwtauth/optional-jwt-auth.guard.ts
+++ b/libs/common/src/guards/jwtauth/optional-jwt-auth.guard.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
+  handleRequest(_error, user) {
+    return user ?? null;
+  }
+}

--- a/libs/common/src/protobuf/reply.ts
+++ b/libs/common/src/protobuf/reply.ts
@@ -16,6 +16,11 @@ export interface Reply {
   avatar: string;
   parentId?: number | undefined;
   replies: Reply[];
+  likeCount: number;
+  dislikeCount: number;
+  userReaction: string;
+  isEdited: boolean;
+  isDeleted: boolean;
 }
 
 export interface RepliesResult {
@@ -26,6 +31,19 @@ export interface RepliesResult {
 export interface GetReplyDto {
   movieId: number;
   page: number;
+  userId?: number | undefined;
+}
+
+export interface ReactReplyDto {
+  userId: number;
+  commentId: number;
+  reaction: string;
+}
+
+export interface ReplyReactionResult {
+  likeCount: number;
+  dislikeCount: number;
+  reaction: string;
 }
 
 export interface CreateReplyDto {
@@ -56,6 +74,8 @@ export interface ReplyServiceClient {
   updateReply(request: UpdateReplyDto): Observable<Empty>;
 
   deleteReply(request: DeleteReplyDto): Observable<Empty>;
+
+  reactReply(request: ReactReplyDto): Observable<ReplyReactionResult>;
 }
 
 export interface ReplyServiceController {
@@ -74,6 +94,13 @@ export interface ReplyServiceController {
   deleteReply(
     request: DeleteReplyDto,
   ): Promise<Empty> | Observable<Empty> | Empty;
+
+  reactReply(
+    request: ReactReplyDto,
+  ):
+    | Promise<ReplyReactionResult>
+    | Observable<ReplyReactionResult>
+    | ReplyReactionResult;
 }
 
 export function ReplyServiceControllerMethods() {
@@ -83,6 +110,7 @@ export function ReplyServiceControllerMethods() {
       'createReply',
       'updateReply',
       'deleteReply',
+      'reactReply',
     ];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(

--- a/prisma/migrations/20260717110000_add_comment_reactions/migration.sql
+++ b/prisma/migrations/20260717110000_add_comment_reactions/migration.sql
@@ -1,0 +1,21 @@
+ALTER TABLE `Comment`
+  ADD COLUMN `isEdited` BOOLEAN NOT NULL DEFAULT false;
+
+CREATE TABLE `comment_reactions` (
+  `id` INTEGER NOT NULL AUTO_INCREMENT,
+  `commentId` INTEGER NOT NULL,
+  `userno` INTEGER NOT NULL,
+  `type` ENUM('like', 'dislike') NOT NULL,
+  `createdAt` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updatedAt` DATETIME(6) NOT NULL,
+  UNIQUE INDEX `CommentReaction_comment_user_unique`(`commentId`, `userno`),
+  INDEX `CommentReaction_comment_type_idx`(`commentId`, `type`),
+  INDEX `CommentReaction_user_idx`(`userno`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `comment_reactions_commentId_fkey`
+    FOREIGN KEY (`commentId`) REFERENCES `Comment`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `comment_reactions_userno_fkey`
+    FOREIGN KEY (`userno`) REFERENCES `User`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -18,14 +18,32 @@ model Comment {
   userno    Int
   comment   String?   @db.LongText
   parentId  Int?
+  isEdited  Boolean   @default(false)
   Movie     Movie     @relation(fields: [movieId], references: [movieCd], onDelete: NoAction, onUpdate: NoAction)
   User      User      @relation(fields: [userno], references: [id], onDelete: Cascade)
   parent    Comment?  @relation("CommentReplies", fields: [parentId], references: [id], onDelete: Cascade)
   replies   Comment[] @relation("CommentReplies")
+  reactions CommentReaction[]
 
   @@index([movieId], map: "movieId_idx")
   @@index([userno], map: "user_no_idx")
   @@index([parentId], map: "Comment_parentId_idx")
+}
+
+model CommentReaction {
+  id        Int                  @id @default(autoincrement())
+  commentId Int
+  userno    Int
+  type      CommentReaction_type
+  createdAt DateTime             @default(now()) @db.DateTime(6)
+  updatedAt DateTime             @updatedAt @db.DateTime(6)
+  Comment   Comment              @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  User      User                 @relation(fields: [userno], references: [id], onDelete: Cascade)
+
+  @@unique([commentId, userno], map: "CommentReaction_comment_user_unique")
+  @@index([commentId, type], map: "CommentReaction_comment_type_idx")
+  @@index([userno], map: "CommentReaction_user_idx")
+  @@map("comment_reactions")
 }
 
 model Movie {
@@ -82,6 +100,7 @@ model User {
   marketing_agreed Boolean            @default(false)
   gender           User_gender?
   Comment          Comment[]
+  CommentReaction  CommentReaction[]
   article          article[]
   articleComments  articleComments[]
   articleLikes     articleLikes[]
@@ -274,6 +293,11 @@ model PublicChatMessage {
 
 
 enum articleLikes_type {
+  like
+  dislike
+}
+
+enum CommentReaction_type {
   like
   dislike
 }

--- a/proto/reply.proto
+++ b/proto/reply.proto
@@ -11,6 +11,7 @@ service ReplyService {
     rpc CreateReply (CreateReplyDto) returns (common.Empty) {}
     rpc UpdateReply (UpdateReplyDto) returns (common.Empty) {}
     rpc DeleteReply (DeleteReplyDto) returns (common.Empty) {}
+    rpc ReactReply (ReactReplyDto) returns (ReplyReactionResult) {}
 }
 
 message Reply {
@@ -24,6 +25,11 @@ message Reply {
     string avatar = 8;
     optional int32 parentId = 9;
     repeated Reply replies = 10;
+    int32 likeCount = 11;
+    int32 dislikeCount = 12;
+    string userReaction = 13;
+    bool isEdited = 14;
+    bool isDeleted = 15;
 }
 
 message RepliesResult {
@@ -34,6 +40,19 @@ message RepliesResult {
 message GetReplyDto {
   int32 movieId = 2;
   int32 page = 3;
+  optional int32 userId = 4;
+}
+
+message ReactReplyDto {
+  int32 userId = 1;
+  int32 commentId = 2;
+  string reaction = 3;
+}
+
+message ReplyReactionResult {
+  int32 likeCount = 1;
+  int32 dislikeCount = 2;
+  string reaction = 3;
 }
 
 message CreateReplyDto {


### PR DESCRIPTION
## Summary
영화 댓글과 대댓글에 좋아요·싫어요 반응을 추가하고 삭제·수정 상태를 안정적으로 보존합니다.

## 변경
- 댓글별 사용자 반응 및 집계 저장 모델·마이그레이션 추가
- 같은 반응 재클릭 시 취소, 반대 반응 클릭 시 전환
- 대댓글이 남은 삭제 부모 댓글을 `삭제된 댓글입니다.`로 조회
- 수정 댓글 `isEdited`, 삭제 댓글 `isDeleted` 상태 반환
- 공개 댓글 조회에서 선택적 JWT로 현재 사용자의 반응 상태 반환

## Test plan
- [x] `pnpm exec jest apps/reply/src/reply.service.spec.ts apps/reply/src/reply.mapper.spec.ts --runInBand`
- [x] `pnpm exec tsc -p apps/reply/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] 수정 TypeScript 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)