### PR TITLE
🐛 공개채팅 프로필을 현재 사용자 정보로 동기화

### DIFF
--- a/apps/chat/src/public-chat.service.spec.ts
+++ b/apps/chat/src/public-chat.service.spec.ts
@@ -1,0 +1,40 @@
+import { PublicChatService } from './public-chat.service';
+
+describe('PublicChatService', () => {
+  it('uses the current user profile for stored chat history', async () => {
+    const prisma = {
+      publicChatMessage: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'message-1',
+            clientId: 'client-1',
+            userId: 4,
+            nickName: '이전 닉네임',
+            image: 'old.png',
+            content: '안녕하세요',
+            createdAt: new Date('2026-07-17T00:00:00.000Z'),
+          },
+        ]),
+      },
+      user: {
+        findMany: jest
+          .fn()
+          .mockResolvedValue([
+            { id: 4, nickname: '현재 닉네임', image: 'current.png' },
+          ]),
+      },
+    };
+    const service = new PublicChatService(prisma as any);
+
+    const [message] = await service.getHistory();
+
+    expect(message).toMatchObject({
+      nickName: '현재 닉네임',
+      image: 'current.png',
+    });
+    expect(prisma.user.findMany).toHaveBeenCalledWith({
+      where: { id: { in: [4] }, deletedAt: null },
+      select: { id: true, nickname: true, image: true },
+    });
+  });
+});

--- a/apps/chat/src/public-chat.service.ts
+++ b/apps/chat/src/public-chat.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { MySQLPrismaService } from '@app/prisma';
+import { DEFAULT_PROFILE_IMAGE_URL } from '@app/common/constants/profile';
 
 export interface PublicChatPayload {
   clientId?: string;
@@ -27,6 +28,12 @@ interface PublicChatRecord {
   image: string | null;
   content: string;
   createdAt: Date;
+}
+
+interface CurrentUserProfile {
+  id: number;
+  nickname: string | null;
+  image: string | null;
 }
 
 interface PublicChatModel {
@@ -67,7 +74,7 @@ export class PublicChatService {
       },
     });
 
-    return this.toView(savedMessage as PublicChatRecord);
+    return this.toView(savedMessage as PublicChatRecord, user);
   }
 
   async getHistory(): Promise<PublicChatMessageView[]> {
@@ -77,22 +84,45 @@ export class PublicChatService {
       take: 80,
     });
 
-    return (messages as PublicChatRecord[])
+    const records = messages as PublicChatRecord[];
+    const userIds = [
+      ...new Set(records.flatMap(({ userId }) => (userId ? [userId] : []))),
+    ];
+    const users = userIds.length
+      ? await this.prisma.user.findMany({
+          where: { id: { in: userIds }, deletedAt: null },
+          select: { id: true, nickname: true, image: true },
+        })
+      : [];
+    const usersById = new Map(users.map((user) => [user.id, user]));
+
+    return records
       .reverse()
-      .map((message) => this.toView(message));
+      .map((message) =>
+        this.toView(
+          message,
+          message.userId ? usersById.get(message.userId) : null,
+        ),
+      );
   }
 
   private get publicChatModel() {
     return this.prisma.publicChatMessage as unknown as PublicChatModel;
   }
 
-  private toView(message: PublicChatRecord): PublicChatMessageView {
+  private toView(
+    message: PublicChatRecord,
+    user?: CurrentUserProfile | null,
+  ): PublicChatMessageView {
+    const image = user
+      ? user.image?.trim() || DEFAULT_PROFILE_IMAGE_URL
+      : message.image?.trim();
     return {
       id: message.id,
       clientId: message.clientId || undefined,
       userId: message.userId || undefined,
-      nickName: message.nickName,
-      image: message.image || undefined,
+      nickName: user?.nickname || message.nickName,
+      image: image || undefined,
       message: message.content,
       createdAt: message.createdAt.toISOString(),
     };


### PR DESCRIPTION
## Summary
공개채팅 과거 메시지의 아바타와 닉네임이 현재 사용자 프로필 변경을 따라가도록 수정합니다.

## 원인
공개채팅 메시지가 작성 당시 nickname/image를 복제 저장하고 그대로 반환해 프로필 변경 후에도 이전 이미지가 노출됐습니다.

## 변경
- 히스토리 조회 시 등록 사용자 ID를 한 번에 조회해 현재 User 프로필 병합
- 등록 사용자의 빈 이미지는 공통 기본 프로필 이미지로 정규화
- 익명 메시지는 저장 당시 표시 정보 유지
- 현재 프로필 우선 동작 회귀 테스트 추가

## Test plan
- [x] `pnpm test -- apps/chat/src/public-chat.service.spec.ts apps/reply/src/reply.mapper.spec.ts apps/article/src/article-comment.service.spec.ts --runInBand`
- [x] `pnpm exec tsc -p apps/chat/tsconfig.app.json --noEmit --incremental false`
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] 변경 파일 200줄 상한 및 `git diff --check`

🤖 Generated with Codex