### PR TITLE
🐛 이미지 업로드 포맷·용량 제한 정합화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,20 @@ jobs:
             echo "▶ 서비스 재시작"
             docker compose -f docker-compose.yml up -d
 
+            echo "▶ 이미지 업로드 용량 제한 적용"
+            docker exec my-nginx sh -c '
+              set -e
+              for config in /etc/nginx/conf.d/*.conf; do
+                if grep -q "client_max_body_size" "$config"; then
+                  sed -i "s/client_max_body_size[^;]*;/client_max_body_size 21m;/g" "$config"
+                else
+                  sed -i "/server_name/a\\    client_max_body_size 21m;" "$config"
+                fi
+              done
+              nginx -t
+              nginx -s reload
+            '
+
             echo "▶ 미사용 이미지 정리"
             docker image prune -f
 

--- a/apps/api-gateway/src/upload/image-multer.options.spec.ts
+++ b/apps/api-gateway/src/upload/image-multer.options.spec.ts
@@ -1,0 +1,38 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  imageMemoryMulterOptions,
+  isAllowedImageFile,
+} from './image-multer.options';
+
+describe('imageMemoryMulterOptions', () => {
+  it.each([
+    ['animation.gif', 'image/gif'],
+    ['photo.avif', 'image/avif'],
+    ['live.heic', 'image/heic-sequence'],
+    ['live.heif', 'image/heif-sequence'],
+    ['IMG_0001.HEIC', 'application/octet-stream'],
+  ])('accepts %s with %s', (originalname, mimetype) => {
+    expect(isAllowedImageFile({ originalname, mimetype })).toBe(true);
+  });
+
+  it('does not trust an image extension with an executable MIME type', () => {
+    expect(
+      isAllowedImageFile({
+        originalname: 'payload.gif',
+        mimetype: 'application/x-msdownload',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns a 400-class error for unsupported files', () => {
+    const callback = jest.fn();
+
+    imageMemoryMulterOptions.fileFilter(
+      {} as never,
+      { originalname: 'photo.dng', mimetype: 'image/x-adobe-dng' } as never,
+      callback,
+    );
+
+    expect(callback).toHaveBeenCalledWith(expect.any(BadRequestException));
+  });
+});

--- a/apps/api-gateway/src/upload/image-multer.options.ts
+++ b/apps/api-gateway/src/upload/image-multer.options.ts
@@ -1,14 +1,34 @@
-import multer from 'multer';
-import { ALLOWED_IMAGE_TYPES, IMAGE_FILE_SIZE_LIMIT } from './upload.constants';
+import { BadRequestException } from '@nestjs/common';
+import * as multer from 'multer';
+import * as path from 'path';
+import {
+  ALLOWED_IMAGE_EXTENSIONS,
+  ALLOWED_IMAGE_TYPES,
+  IMAGE_FILE_SIZE_LIMIT,
+} from './upload.constants';
+
+interface ImageFileIdentity {
+  mimetype: string;
+  originalname: string;
+}
+
+export function isAllowedImageFile(file: ImageFileIdentity): boolean {
+  if (ALLOWED_IMAGE_TYPES.includes(file.mimetype)) return true;
+
+  const genericMime =
+    !file.mimetype || file.mimetype === 'application/octet-stream';
+  const extension = path.extname(file.originalname).toLowerCase();
+  return genericMime && ALLOWED_IMAGE_EXTENSIONS.includes(extension);
+}
 
 export const imageMemoryMulterOptions = {
   storage: multer.memoryStorage(),
   limits: { fileSize: IMAGE_FILE_SIZE_LIMIT },
   fileFilter: (req, file, cb) => {
-    if (ALLOWED_IMAGE_TYPES.includes(file.mimetype)) {
+    if (isAllowedImageFile(file)) {
       cb(null, true);
       return;
     }
-    cb(new Error('지원되지 않는 파일 형식입니다.'));
+    cb(new BadRequestException('지원되지 않는 파일 형식입니다.'));
   },
 };

--- a/apps/api-gateway/src/upload/upload.constants.ts
+++ b/apps/api-gateway/src/upload/upload.constants.ts
@@ -4,8 +4,22 @@ export const ALLOWED_IMAGE_TYPES = [
   'image/gif',
   'image/jpg',
   'image/heic',
+  'image/heic-sequence',
   'image/heif',
+  'image/heif-sequence',
   'image/webp',
+  'image/avif',
+];
+
+export const ALLOWED_IMAGE_EXTENSIONS = [
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.gif',
+  '.webp',
+  '.avif',
+  '.heic',
+  '.heif',
 ];
 
 export const IMAGE_FILE_SIZE_LIMIT = 20 * 1024 * 1024;


### PR DESCRIPTION
## Summary
GIF와 아이폰 이미지가 API 진입 전에 차단되지 않도록 업로드 허용 형식과 Nginx 요청 제한을 정리합니다.

## 원인
백엔드는 20MB를 허용했지만 운영 Nginx가 기본 약 1MB 제한을 사용해 2MB GIF도 413으로 차단했습니다. iPhone은 HEIC/HEIF sequence 또는 비어 있는 MIME을 보낼 수 있고, 기존 필터는 이를 일부 거절했습니다.

## 변경
- GIF·AVIF·HEIC/HEIF sequence MIME 허용
- MIME이 없거나 octet-stream인 정상 이미지 확장자 fallback 추가
- 미지원 형식을 BadRequestException으로 반환
- 배포 시 실행 중인 Nginx 제한을 21MB로 멱등 적용하고 설정 검사 후 reload

## Test plan
- [x] 업로드 필터 Jest 7개 통과
- [x] 백엔드 전체 테스트 중 신규 포함 7 suites/22 tests 통과
- [x] 기존 ArticleController/ArticleService 생성 테스트 2개만 기존 DI 설정 문제로 실패
- [x] `pnpm exec tsc -p apps/api-gateway/tsconfig.app.json --noEmit --incremental false`
- [x] Prettier, 200줄 상한, `git diff --check`
- [ ] master 머지 후 배포 및 운영 2MB GIF 요청이 401(애플리케이션 도달)로 바뀌는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)