### PR TITLE
✨ 매칭 응답에 영화 포스터 추가

### DIFF
--- a/apps/match/src/match-post.presenter.ts
+++ b/apps/match/src/match-post.presenter.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { MatchPost } from '@app/common/protobuf';
+import { formatMatchPost, PostWithUserAndCount } from './match.formatter';
+import { MatchPosterService } from './match-poster.service';
+
+@Injectable()
+export class MatchPostPresenter {
+  constructor(private readonly posters: MatchPosterService) {}
+
+  async many(posts: PostWithUserAndCount[]): Promise<MatchPost[]> {
+    const posterMap = await this.posters.getPosterMap(
+      posts.map((post) => post.movieTitle),
+    );
+    return posts.map((post) =>
+      formatMatchPost(post, posterMap.get(post.movieTitle) || ''),
+    );
+  }
+
+  async one(post: PostWithUserAndCount): Promise<MatchPost> {
+    const [formatted] = await this.many([post]);
+    return formatted;
+  }
+}

--- a/apps/match/src/match-post.service.ts
+++ b/apps/match/src/match-post.service.ts
@@ -16,7 +16,7 @@ import {
   SingleMatchPostResponse,
   CommonResponse,
 } from '@app/common/protobuf';
-import { formatMatchPost } from './match.formatter';
+import { MatchPostPresenter } from './match-post.presenter';
 import {
   buildMatchPostWhere,
   isAvailablePost,
@@ -35,7 +35,10 @@ const POST_INCLUDE = {
 @Injectable()
 export class MatchPostService {
   private readonly logger = new Logger(MatchPostService.name);
-  constructor(private readonly prisma: MySQLPrismaService) {}
+  constructor(
+    private readonly prisma: MySQLPrismaService,
+    private readonly presenter: MatchPostPresenter,
+  ) {}
 
   async getMatchPosts(
     request: GetMatchPostsRequest,
@@ -57,7 +60,7 @@ export class MatchPostService {
       const pagePosts = paginate(availablePosts, skip, pageSize);
 
       return {
-        matchPosts: pagePosts.map(formatMatchPost),
+        matchPosts: await this.presenter.many(pagePosts),
         hasNext: availablePosts.length > skip + pageSize,
       };
     }
@@ -74,7 +77,7 @@ export class MatchPostService {
     if (hasNext) matchPosts.pop();
 
     return {
-      matchPosts: matchPosts.map(formatMatchPost),
+      matchPosts: await this.presenter.many(matchPosts),
       hasNext,
     };
   }
@@ -107,7 +110,7 @@ export class MatchPostService {
       include: POST_INCLUDE,
     });
 
-    return { matchPost: formatMatchPost(matchPost) };
+    return { matchPost: await this.presenter.one(matchPost) };
   }
 
   async getMatchPost(
@@ -118,7 +121,7 @@ export class MatchPostService {
       include: POST_INCLUDE,
     });
     if (!matchPost) return { matchPost: null };
-    return { matchPost: formatMatchPost(matchPost) };
+    return { matchPost: await this.presenter.one(matchPost) };
   }
 
   async updateMatchPost(
@@ -140,7 +143,7 @@ export class MatchPostService {
       include: POST_INCLUDE,
     });
 
-    return { matchPost: formatMatchPost(updatedPost) };
+    return { matchPost: await this.presenter.one(updatedPost) };
   }
 
   async deleteMatchPost(
@@ -180,7 +183,7 @@ export class MatchPostService {
     if (hasNext) matchPosts.pop();
 
     return {
-      matchPosts: matchPosts.map(formatMatchPost),
+      matchPosts: await this.presenter.many(matchPosts),
       hasNext,
     };
   }

--- a/apps/match/src/match-poster.service.spec.ts
+++ b/apps/match/src/match-poster.service.spec.ts
@@ -1,0 +1,22 @@
+import { MatchPosterService } from './match-poster.service';
+
+describe('MatchPosterService', () => {
+  it('중복 제목을 한 번만 조회하고 포스터 URL을 제목별로 반환한다', async () => {
+    const findMany = jest.fn().mockResolvedValue([
+      { title: '군체', poster: 'https://cdn.example.com/colony.jpg' },
+      { title: '모아나', poster: null },
+    ]);
+    const service = new MatchPosterService({ movie: { findMany } } as never);
+
+    const posters = await service.getPosterMap(['군체', '군체', '모아나']);
+
+    expect(findMany).toHaveBeenCalledTimes(1);
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { title: { in: ['군체', '모아나'] }, poster: { not: null } },
+      }),
+    );
+    expect(posters.get('군체')).toBe('https://cdn.example.com/colony.jpg');
+    expect(posters.has('모아나')).toBe(false);
+  });
+});

--- a/apps/match/src/match-poster.service.ts
+++ b/apps/match/src/match-poster.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { MySQLPrismaService } from '@app/prisma';
+
+@Injectable()
+export class MatchPosterService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async getPosterMap(movieTitles: string[]): Promise<Map<string, string>> {
+    const titles = [
+      ...new Set(movieTitles.map((title) => title.trim()).filter(Boolean)),
+    ];
+    if (titles.length === 0) return new Map();
+
+    const movies = await this.prisma.movie.findMany({
+      where: { title: { in: titles }, poster: { not: null } },
+      select: { title: true, poster: true },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    const posters = new Map<string, string>();
+    movies.forEach(({ title, poster }) => {
+      if (title && poster && !posters.has(title)) posters.set(title, poster);
+    });
+    return posters;
+  }
+}

--- a/apps/match/src/match.formatter.ts
+++ b/apps/match/src/match.formatter.ts
@@ -1,6 +1,6 @@
 import { MatchApplication, MatchPost } from '@app/common/protobuf';
 
-type PostWithUserAndCount = {
+export type PostWithUserAndCount = {
   id: string;
   title: string;
   userno: number;
@@ -17,7 +17,10 @@ type PostWithUserAndCount = {
   _count: { MatchApplication: number };
 };
 
-export function formatMatchPost(post: PostWithUserAndCount): MatchPost {
+export function formatMatchPost(
+  post: PostWithUserAndCount,
+  moviePoster = '',
+): MatchPost {
   return {
     id: post.id,
     title: post.title,
@@ -26,6 +29,7 @@ export function formatMatchPost(post: PostWithUserAndCount): MatchPost {
     authorGender: post.User.gender || '',
     content: post.content,
     movieTitle: post.movieTitle,
+    moviePoster,
     theaterName: post.theaterName,
     showTime: post.showTime,
     maxParticipants: post.maxParticipants,

--- a/apps/match/src/match.module.ts
+++ b/apps/match/src/match.module.ts
@@ -8,6 +8,8 @@ import { MatchController } from './match.controller';
 import { MatchService } from './match.service';
 import { MatchPostService } from './match-post.service';
 import { MatchApplicationService } from './match-application.service';
+import { MatchPosterService } from './match-poster.service';
+import { MatchPostPresenter } from './match-post.presenter';
 
 @Module({
   imports: [
@@ -26,6 +28,12 @@ import { MatchApplicationService } from './match-application.service';
     ]),
   ],
   controllers: [MatchController],
-  providers: [MatchService, MatchPostService, MatchApplicationService],
+  providers: [
+    MatchService,
+    MatchPostService,
+    MatchApplicationService,
+    MatchPosterService,
+    MatchPostPresenter,
+  ],
 })
 export class MatchModule {}

--- a/libs/common/src/protobuf/match.ts
+++ b/libs/common/src/protobuf/match.ts
@@ -21,6 +21,7 @@ export interface MatchPost {
   createdAt: string;
   updatedAt: string;
   deletedAt: string;
+  moviePoster: string;
 }
 
 export interface MatchApplication {

--- a/proto/match.proto
+++ b/proto/match.proto
@@ -19,6 +19,7 @@ message MatchPost {
   string createdAt = 13;
   string updatedAt = 14;
   string deletedAt = 15;
+  string moviePoster = 16;
 }
 
 message MatchApplication {


### PR DESCRIPTION
## Summary
매칭 목록·상세 응답에 해당 영화의 포스터 URL을 보강합니다.

## 원인
매칭 데이터에는 영화 제목만 저장되어 있어 프론트가 포스터를 표시할 수 없었습니다.

## 변경
- gRPC `MatchPost`에 `moviePoster` 추가
- 페이지 내 영화 제목을 중복 제거하고 Prisma 한 번의 조회로 포스터 보강
- 생성·상세·수정·내 매칭 응답에도 동일 계약 적용

## Test plan
- [x] `pnpm exec jest apps/match/src/match-poster.service.spec.ts --runInBand`
- [x] Prisma 재생성 상태에서 match/api-gateway TypeScript 검사
- [x] 수정/신규 수동 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)