### PR TITLE
✨ 아티클 일별 조회수 집계 추가

### DIFF
--- a/apps/api-gateway/src/article/article-view.controller.spec.ts
+++ b/apps/api-gateway/src/article/article-view.controller.spec.ts
@@ -1,0 +1,29 @@
+import { BadRequestException } from '@nestjs/common';
+import { ArticleViewController } from './article-view.controller';
+
+describe('ArticleViewController', () => {
+  const recordArticleView = jest.fn();
+  const controller = new ArticleViewController({ recordArticleView } as any);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('forwards a SHA-256 viewer key to the article service', async () => {
+    recordArticleView.mockResolvedValue({ viewCount: 3, counted: true });
+    const viewerKey = 'a'.repeat(64);
+
+    const result = await controller.recordArticleView('4', { viewerKey });
+
+    expect(recordArticleView).toHaveBeenCalledWith({
+      articleId: 4,
+      viewerKey,
+    });
+    expect(result).toEqual({ viewCount: 3, counted: true });
+  });
+
+  it('rejects a viewer key that is not a SHA-256 digest', () => {
+    expect(() =>
+      controller.recordArticleView('4', { viewerKey: 'raw-cookie-value' }),
+    ).toThrow(BadRequestException);
+    expect(recordArticleView).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api-gateway/src/article/article-view.controller.ts
+++ b/apps/api-gateway/src/article/article-view.controller.ts
@@ -1,0 +1,28 @@
+import { RecordArticleViewRequest } from '@app/common/protobuf';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { ArticleService } from './article.service';
+
+@Controller('article')
+export class ArticleViewController {
+  constructor(private readonly articleService: ArticleService) {}
+
+  @Post(':id/view')
+  recordArticleView(
+    @Param('id') id: string,
+    @Body() body: Pick<RecordArticleViewRequest, 'viewerKey'>,
+  ) {
+    if (!/^[a-f0-9]{64}$/.test(body.viewerKey)) {
+      throw new BadRequestException('Invalid viewer key');
+    }
+    return this.articleService.recordArticleView({
+      articleId: Number(id),
+      viewerKey: body.viewerKey,
+    });
+  }
+}

--- a/apps/api-gateway/src/article/article.module.ts
+++ b/apps/api-gateway/src/article/article.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ArticleService } from './article.service';
 import { ArticleController } from './article.controller';
+import { ArticleViewController } from './article-view.controller';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import { join } from 'path';
 import { ARTICLE_PACKAGE_NAME } from '@app/common/protobuf';
@@ -21,7 +22,7 @@ import { UploadModule } from '../upload/upload.module';
       },
     ]),
   ],
-  controllers: [ArticleController],
+  controllers: [ArticleController, ArticleViewController],
   providers: [ArticleService],
 })
 export class ArticleModule {}

--- a/apps/api-gateway/src/article/article.service.ts
+++ b/apps/api-gateway/src/article/article.service.ts
@@ -14,6 +14,7 @@ import {
   UpdateArticleRequest,
   UpdateCommentRequest,
   ReactCommentRequest,
+  RecordArticleViewRequest,
 } from '@app/common/protobuf';
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { ClientGrpc } from '@nestjs/microservices';
@@ -49,6 +50,9 @@ export class ArticleService implements OnModuleInit {
 
   async deleteArticle(request: DeleteArticleRequest) {
     return this.articleService.deleteArticle(request);
+  }
+  async recordArticleView(request: RecordArticleViewRequest) {
+    return this.articleService.recordArticleView(request);
   }
   async createComment(request: CreateCommentRequest) {
     return this.articleService.createComment(request);

--- a/apps/article/src/article-crud.service.ts
+++ b/apps/article/src/article-crud.service.ts
@@ -34,6 +34,7 @@ export class ArticleCrudService {
       likeCount: article.like_count,
       dislikeCount: article.dislike_count,
       commentCount: article.comment_count,
+      viewCount: article.view_count,
       createdAt: article.createdAt.toISOString(),
       updatedAt: article.updatedAt.toISOString(),
       deletedAt: this.utilsService.toNullableISOString(article.deletedAt),

--- a/apps/article/src/article-view.service.spec.ts
+++ b/apps/article/src/article-view.service.spec.ts
@@ -1,0 +1,65 @@
+import { ArticleViewService, toKstDate } from './article-view.service';
+
+describe('ArticleViewService', () => {
+  const article = { id: 4, view_count: 7 };
+  let transaction: any;
+  let prisma: any;
+
+  beforeEach(() => {
+    transaction = {
+      articleView: { createMany: jest.fn() },
+      article: {
+        update: jest.fn(),
+        findUniqueOrThrow: jest.fn(),
+      },
+    };
+    prisma = {
+      article: { findFirst: jest.fn().mockResolvedValue(article) },
+      $transaction: jest.fn((callback) => callback(transaction)),
+    };
+  });
+
+  it('increments the count for the first view of the KST day', async () => {
+    transaction.articleView.createMany.mockResolvedValue({ count: 1 });
+    transaction.article.update.mockResolvedValue({ view_count: 8 });
+    const service = new ArticleViewService(prisma);
+
+    const result = await service.recordView(
+      { articleId: 4, viewerKey: 'a'.repeat(64) },
+      new Date('2026-07-20T15:30:00.000Z'),
+    );
+
+    expect(transaction.articleView.createMany).toHaveBeenCalledWith({
+      data: {
+        articleId: 4,
+        viewerKey: 'a'.repeat(64),
+        viewedOn: new Date('2026-07-21T00:00:00.000Z'),
+      },
+      skipDuplicates: true,
+    });
+    expect(result).toEqual({ viewCount: 8, counted: true });
+  });
+
+  it('keeps the count for a duplicate view on the same KST day', async () => {
+    transaction.articleView.createMany.mockResolvedValue({ count: 0 });
+    transaction.article.findUniqueOrThrow.mockResolvedValue(article);
+    const service = new ArticleViewService(prisma);
+
+    const result = await service.recordView({
+      articleId: 4,
+      viewerKey: 'b'.repeat(64),
+    });
+
+    expect(transaction.article.update).not.toHaveBeenCalled();
+    expect(result).toEqual({ viewCount: 7, counted: false });
+  });
+
+  it('converts timestamps to the Asia/Seoul calendar date', () => {
+    expect(toKstDate(new Date('2026-07-20T14:59:59.000Z'))).toEqual(
+      new Date('2026-07-20T00:00:00.000Z'),
+    );
+    expect(toKstDate(new Date('2026-07-20T15:00:00.000Z'))).toEqual(
+      new Date('2026-07-21T00:00:00.000Z'),
+    );
+  });
+});

--- a/apps/article/src/article-view.service.ts
+++ b/apps/article/src/article-view.service.ts
@@ -1,0 +1,59 @@
+import {
+  RecordArticleViewRequest,
+  RecordArticleViewResponse,
+} from '@app/common/protobuf';
+import { MySQLPrismaService } from '@app/prisma';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+export const toKstDate = (date: Date): Date => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const value = Object.fromEntries(
+    parts.map(({ type, value }) => [type, value]),
+  );
+  return new Date(`${value.year}-${value.month}-${value.day}T00:00:00.000Z`);
+};
+
+@Injectable()
+export class ArticleViewService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async recordView(
+    request: RecordArticleViewRequest,
+    now = new Date(),
+  ): Promise<RecordArticleViewResponse> {
+    const article = await this.prisma.article.findFirst({
+      where: { id: request.articleId, deletedAt: null },
+      select: { id: true, view_count: true },
+    });
+    if (!article) throw new NotFoundException('Article not found');
+
+    return this.prisma.$transaction(async (tx) => {
+      const created = await tx.articleView.createMany({
+        data: {
+          articleId: request.articleId,
+          viewerKey: request.viewerKey,
+          viewedOn: toKstDate(now),
+        },
+        skipDuplicates: true,
+      });
+      if (created.count === 0) {
+        const current = await tx.article.findUniqueOrThrow({
+          where: { id: request.articleId },
+          select: { view_count: true },
+        });
+        return { viewCount: current.view_count, counted: false };
+      }
+      const updated = await tx.article.update({
+        where: { id: request.articleId },
+        data: { view_count: { increment: 1 } },
+        select: { view_count: true },
+      });
+      return { viewCount: updated.view_count, counted: true };
+    });
+  }
+}

--- a/apps/article/src/article.controller.ts
+++ b/apps/article/src/article.controller.ts
@@ -21,6 +21,8 @@ import {
   UpdateArticleRequest,
   UpdateCommentRequest,
   ReactCommentRequest,
+  RecordArticleViewRequest,
+  RecordArticleViewResponse,
   CommentReactionResponse,
 } from '@app/common/protobuf';
 
@@ -57,6 +59,12 @@ export class ArticleController implements ArticleServiceController {
 
   async deleteArticle(request: DeleteArticleRequest): Promise<Empty> {
     return this.articleService.deleteArticle(request);
+  }
+
+  async recordArticleView(
+    request: RecordArticleViewRequest,
+  ): Promise<RecordArticleViewResponse> {
+    return this.articleService.recordArticleView(request);
   }
 
   async createComment(request: CreateCommentRequest): Promise<ArticleComment> {

--- a/apps/article/src/article.module.ts
+++ b/apps/article/src/article.module.ts
@@ -4,6 +4,7 @@ import { ArticleService } from './article.service';
 import { ArticleCrudService } from './article-crud.service';
 import { ArticleCommentService } from './article-comment.service';
 import { ArticleLikeService } from './article-like.service';
+import { ArticleViewService } from './article-view.service';
 import { PrismaModule } from '@app/prisma';
 import { UtilsModule } from '@app/utils';
 
@@ -15,6 +16,7 @@ import { UtilsModule } from '@app/utils';
     ArticleCrudService,
     ArticleCommentService,
     ArticleLikeService,
+    ArticleViewService,
   ],
 })
 export class ArticleModule {}

--- a/apps/article/src/article.service.ts
+++ b/apps/article/src/article.service.ts
@@ -12,11 +12,13 @@ import {
   UpdateArticleRequest,
   UpdateCommentRequest,
   ReactCommentRequest,
+  RecordArticleViewRequest,
 } from '@app/common/protobuf';
 import { GetArticleRequest } from 'proto/article';
 import { ArticleCrudService } from './article-crud.service';
 import { ArticleCommentService } from './article-comment.service';
 import { ArticleLikeService } from './article-like.service';
+import { ArticleViewService } from './article-view.service';
 
 @Injectable()
 export class ArticleService {
@@ -24,6 +26,7 @@ export class ArticleService {
     private readonly crud: ArticleCrudService,
     private readonly commentService: ArticleCommentService,
     private readonly likeService: ArticleLikeService,
+    private readonly viewService: ArticleViewService,
   ) {}
 
   // Article CRUD
@@ -41,6 +44,9 @@ export class ArticleService {
   }
   deleteArticle(req: DeleteArticleRequest) {
     return this.crud.deleteArticle(req);
+  }
+  recordArticleView(req: RecordArticleViewRequest) {
+    return this.viewService.recordView(req);
   }
 
   // Comments

--- a/libs/common/src/protobuf/article.ts
+++ b/libs/common/src/protobuf/article.ts
@@ -25,6 +25,7 @@ export interface Article {
   updatedAt: string;
   deletedAt: string;
   author: string;
+  viewCount: number;
 }
 
 export interface CreateArticleRequest {
@@ -67,6 +68,16 @@ export interface DeleteArticleRequest {
   userno: number;
 }
 
+export interface RecordArticleViewRequest {
+  articleId: number;
+  viewerKey: string;
+}
+
+export interface RecordArticleViewResponse {
+  viewCount: number;
+  counted: boolean;
+}
+
 /** ===== Comment ===== */
 export interface ArticleComment {
   id: number;
@@ -78,7 +89,7 @@ export interface ArticleComment {
   deletedAt: string;
   nickname: string;
   avatar: string;
-  parentId: number;
+  parentId?: number | undefined;
   replies: ArticleComment[];
   likeCount: number;
   dislikeCount: number;
@@ -91,7 +102,7 @@ export interface CreateCommentRequest {
   articleId: number;
   userno: number;
   content: string;
-  parentId: number;
+  parentId?: number | undefined;
 }
 
 export interface GetCommentRequest {
@@ -113,7 +124,7 @@ export interface ListCommentsRequest {
   articleId: number;
   page: number;
   pageSize: number;
-  userno: number;
+  userno?: number | undefined;
 }
 
 export interface ListCommentsResponse {
@@ -181,6 +192,10 @@ export interface ArticleServiceClient {
 
   deleteArticle(request: DeleteArticleRequest): Observable<Empty>;
 
+  recordArticleView(
+    request: RecordArticleViewRequest,
+  ): Observable<RecordArticleViewResponse>;
+
   /** Comment */
 
   createComment(request: CreateCommentRequest): Observable<ArticleComment>;
@@ -243,6 +258,13 @@ export interface ArticleServiceController {
     request: DeleteArticleRequest,
   ): Promise<Empty> | Observable<Empty> | Empty;
 
+  recordArticleView(
+    request: RecordArticleViewRequest,
+  ):
+    | Promise<RecordArticleViewResponse>
+    | Observable<RecordArticleViewResponse>
+    | RecordArticleViewResponse;
+
   /** Comment */
 
   createComment(
@@ -297,6 +319,7 @@ export function ArticleServiceControllerMethods() {
       'listArticles',
       'updateArticle',
       'deleteArticle',
+      'recordArticleView',
       'createComment',
       'getComment',
       'updateComment',

--- a/prisma/migrations/20260720000000_add_article_views/migration.sql
+++ b/prisma/migrations/20260720000000_add_article_views/migration.sql
@@ -1,0 +1,16 @@
+ALTER TABLE `article`
+  ADD COLUMN `view_count` INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE `article_views` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `articleId` INTEGER NOT NULL,
+  `viewerKey` CHAR(64) NOT NULL,
+  `viewedOn` DATE NOT NULL,
+  `createdAt` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  UNIQUE INDEX `ArticleView_daily_unique`(`articleId`, `viewerKey`, `viewedOn`),
+  INDEX `ArticleView_article_date_idx`(`articleId`, `viewedOn`),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `article_views_articleId_fkey`
+    FOREIGN KEY (`articleId`) REFERENCES `article`(`id`)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/mysql.schema.prisma
+++ b/prisma/mysql.schema.prisma
@@ -153,14 +153,29 @@ model article {
   like_count      Int               @default(0)
   dislike_count   Int               @default(0)
   comment_count   Int               @default(0)
+  view_count      Int               @default(0)
   createdAt       DateTime          @default(now()) @db.DateTime(6)
   updatedAt       DateTime          @default(now()) @db.DateTime(6)
   deletedAt       DateTime?         @db.DateTime(6)
   User            User              @relation(fields: [userno], references: [id], onDelete: Cascade, map: "Article_userno_fkey")
   articleComments articleComments[]
   articleLikes    articleLikes[]
+  articleViews    ArticleView[]
 
   @@index([userno], map: "Article_userno_fkey_idx")
+}
+
+model ArticleView {
+  id        BigInt   @id @default(autoincrement())
+  articleId Int
+  viewerKey String   @db.Char(64)
+  viewedOn  DateTime @db.Date
+  createdAt DateTime @default(now()) @db.DateTime(6)
+  article   article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
+
+  @@unique([articleId, viewerKey, viewedOn], map: "ArticleView_daily_unique")
+  @@index([articleId, viewedOn], map: "ArticleView_article_date_idx")
+  @@map("article_views")
 }
 
 model articleComments {

--- a/proto/article.proto
+++ b/proto/article.proto
@@ -17,6 +17,7 @@ message Article {
   string updatedAt = 9;
   string deletedAt = 10;
   string author = 11;
+  int32 view_count = 12;
 }
 
 message CreateArticleRequest {
@@ -57,6 +58,16 @@ message UpdateArticleRequest {
 message DeleteArticleRequest {
   int32 id = 1;
   int32 userno = 2;
+}
+
+message RecordArticleViewRequest {
+  int32 articleId = 1;
+  string viewerKey = 2;
+}
+
+message RecordArticleViewResponse {
+  int32 viewCount = 1;
+  bool counted = 2;
 }
 
 // ===== Comment =====
@@ -166,6 +177,7 @@ service ArticleService {
   rpc ListArticles (ListArticlesRequest) returns (ListArticlesResponse);
   rpc UpdateArticle (UpdateArticleRequest) returns (CreateArticleResponse);
   rpc DeleteArticle (DeleteArticleRequest) returns (common.Empty);
+  rpc RecordArticleView (RecordArticleViewRequest) returns (RecordArticleViewResponse);
 
   // Comment
   rpc CreateComment (CreateCommentRequest) returns (ArticleComment);


### PR DESCRIPTION
## Summary
아티클별 누적 조회수와 브라우저 기준 KST 하루 1회 중복 방지 집계를 추가합니다.

## 원인
기존 아티클 모델과 응답에는 조회 정보가 없어서 콘텐츠 반응을 확인할 수 없었습니다.

## 변경
- article에 view_count 및 일별 익명 조회 기록 테이블 추가
- DB 유니크 키와 트랜잭션으로 동시 중복 증가 방지
- 공개 gRPC/REST 조회 기록 API와 SHA-256 형식 검증 추가
- 목록·상세 응답에 viewCount 포함

## Test plan
- [x] pnpm exec jest article view tests
- [x] article/api-gateway TypeScript 검사
- [x] Prisma schema validate
- [x] 수동 작성 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)