### PR TITLE
✨ 마이페이지 커뮤니티 활동 집계 API

### DIFF
--- a/apps/api-gateway/src/user/user-activity.controller.spec.ts
+++ b/apps/api-gateway/src/user/user-activity.controller.spec.ts
@@ -1,0 +1,32 @@
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { JwtAuthGuard } from '@app/common/guards/jwtauth/jwtauth.guard';
+import { UserController } from './user.controller';
+
+describe('UserController activity summary', () => {
+  const activityService = { getSummary: jest.fn() };
+  const controller = new UserController(
+    {} as never,
+    {} as never,
+    activityService as never,
+  );
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('uses the authenticated user id', async () => {
+    activityService.getSummary.mockResolvedValue({ articleCount: 1 });
+
+    await expect(
+      controller.getActivitySummary({ user: { userId: 4 } }),
+    ).resolves.toEqual({ articleCount: 1 });
+    expect(activityService.getSummary).toHaveBeenCalledWith(4);
+  });
+
+  it('is protected by the JWT guard', () => {
+    const guards = Reflect.getMetadata(
+      GUARDS_METADATA,
+      controller.getActivitySummary,
+    );
+
+    expect(guards).toContain(JwtAuthGuard);
+  });
+});

--- a/apps/api-gateway/src/user/user-activity.service.spec.ts
+++ b/apps/api-gateway/src/user/user-activity.service.spec.ts
@@ -1,0 +1,66 @@
+import { UserActivityService } from './user-activity.service';
+
+describe('UserActivityService', () => {
+  const prisma = {
+    user: { count: jest.fn() },
+    articleComments: { count: jest.fn() },
+    movieScore: { count: jest.fn() },
+    article: {
+      count: jest.fn(),
+      aggregate: jest.fn(),
+    },
+  };
+
+  const service = new UserActivityService(prisma as never);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.user.count.mockResolvedValue(1);
+  });
+
+  it('returns the signed-in user community activity summary', async () => {
+    prisma.articleComments.count.mockResolvedValue(7);
+    prisma.movieScore.count.mockResolvedValue(4);
+    prisma.article.count.mockResolvedValue(2);
+    prisma.article.aggregate.mockResolvedValue({ _sum: { like_count: 13 } });
+
+    await expect(service.getSummary(4)).resolves.toEqual({
+      articleCommentCount: 7,
+      movieRatingCount: 4,
+      articleCount: 2,
+      receivedLikeCount: 13,
+    });
+    expect(prisma.articleComments.count).toHaveBeenCalledWith({
+      where: {
+        userno: 4,
+        deletedAt: null,
+        article: { deletedAt: null },
+      },
+    });
+    expect(prisma.movieScore.count).toHaveBeenCalledWith({
+      where: { Userno: 4, deletedAt: null },
+    });
+    expect(prisma.article.aggregate).toHaveBeenCalledWith({
+      where: { userno: 4, deletedAt: null },
+      _sum: { like_count: true },
+    });
+  });
+
+  it('normalizes an empty received-like sum to zero', async () => {
+    prisma.articleComments.count.mockResolvedValue(0);
+    prisma.movieScore.count.mockResolvedValue(0);
+    prisma.article.count.mockResolvedValue(0);
+    prisma.article.aggregate.mockResolvedValue({ _sum: { like_count: null } });
+
+    await expect(service.getSummary(4)).resolves.toMatchObject({
+      receivedLikeCount: 0,
+    });
+  });
+
+  it('rejects a soft-deleted user even with a signed token', async () => {
+    prisma.user.count.mockResolvedValue(0);
+
+    await expect(service.getSummary(4)).rejects.toThrow('로그인이 필요합니다.');
+    expect(prisma.articleComments.count).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api-gateway/src/user/user-activity.service.ts
+++ b/apps/api-gateway/src/user/user-activity.service.ts
@@ -1,0 +1,44 @@
+import { MySQLPrismaService } from '@app/prisma';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+
+@Injectable()
+export class UserActivityService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  async getSummary(userId: number) {
+    const activeUserCount = await this.prisma.user.count({
+      where: { id: userId, deletedAt: null },
+    });
+    if (activeUserCount === 0) {
+      throw new UnauthorizedException('로그인이 필요합니다.');
+    }
+
+    const [articleCommentCount, movieRatingCount, articleCount, likes] =
+      await Promise.all([
+        this.prisma.articleComments.count({
+          where: {
+            userno: userId,
+            deletedAt: null,
+            article: { deletedAt: null },
+          },
+        }),
+        this.prisma.movieScore.count({
+          where: { Userno: userId, deletedAt: null },
+        }),
+        this.prisma.article.count({
+          where: { userno: userId, deletedAt: null },
+        }),
+        this.prisma.article.aggregate({
+          where: { userno: userId, deletedAt: null },
+          _sum: { like_count: true },
+        }),
+      ]);
+
+    return {
+      articleCommentCount,
+      movieRatingCount,
+      articleCount,
+      receivedLikeCount: likes._sum.like_count ?? 0,
+    };
+  }
+}

--- a/apps/api-gateway/src/user/user.controller.ts
+++ b/apps/api-gateway/src/user/user.controller.ts
@@ -25,6 +25,7 @@ import { FilesInterceptor } from '@nestjs/platform-express';
 import { convertToUserEntity } from '@app/common/entity';
 import { imageMemoryMulterOptions } from '../upload/image-multer.options';
 import { UploadService } from '../upload/upload.service';
+import { UserActivityService } from './user-activity.service';
 
 @Controller('user')
 export class UserController {
@@ -32,6 +33,7 @@ export class UserController {
   constructor(
     private readonly userService: UserService,
     private readonly uploadService: UploadService,
+    private readonly userActivityService: UserActivityService,
   ) {}
   @CreateUserSpecDecorator('회원가입 API', '회원가입')
   @Post('/')
@@ -56,6 +58,12 @@ export class UserController {
       }),
     );
     return convertToUserEntity(result);
+  }
+
+  @Get('/activity-summary')
+  @UseGuards(JwtAuthGuard, RateLimitGuard)
+  getActivitySummary(@Req() req) {
+    return this.userActivityService.getSummary(req.user.userId);
   }
 
   @Get('/:id')

--- a/apps/api-gateway/src/user/user.module.ts
+++ b/apps/api-gateway/src/user/user.module.ts
@@ -5,9 +5,12 @@ import { join } from 'path';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { UploadModule } from '../upload/upload.module';
+import { PrismaModule } from '@app/prisma';
+import { UserActivityService } from './user-activity.service';
 @Module({
   imports: [
     UploadModule,
+    PrismaModule,
     ClientsModule.register([
       {
         name: USER_PACKAGE_NAME,
@@ -21,6 +24,6 @@ import { UploadModule } from '../upload/upload.module';
     ]),
   ],
   controllers: [UserController],
-  providers: [UserService],
+  providers: [UserService, UserActivityService],
 })
 export class UserModule {}


### PR DESCRIPTION
## Summary
마이페이지용 사용자 커뮤니티 활동 지표를 인증 API 한 번으로 제공합니다.

## 변경
- `GET /user/activity-summary` 추가
- 작성 아티클 댓글·영화 평점·게시글·받은 좋아요 병렬 집계
- soft-delete된 활동, 삭제된 부모 게시글 댓글, 탈퇴 사용자 제외
- JWT guard와 인증 사용자 ID 전달 회귀 테스트 추가

## Test plan
- [x] `pnpm test -- --runInBand apps/api-gateway/src/user/user-activity.service.spec.ts apps/api-gateway/src/user/user-activity.controller.spec.ts` (5 tests)
- [x] 변경 파일 ESLint
- [x] `pnpm exec nest build api-gateway` webpack compile 성공
- [x] 수정 파일 200줄 상한 확인

## 참고
- TypeScript 5.1/Prisma 전체 `tsc --noEmit`의 스택 초과는 동일한 origin/master에서도 재현되는 기존 로컬 도구체인 문제입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)