### PR TITLE
✨ 마이페이지 활동 목록·평점 삭제 추가

### DIFF
--- a/apps/api-gateway/src/user/user-activity-list.service.spec.ts
+++ b/apps/api-gateway/src/user/user-activity-list.service.spec.ts
@@ -1,0 +1,133 @@
+import { BadRequestException } from '@nestjs/common';
+import { UserActivityService } from './user-activity.service';
+
+describe('UserActivityService activity lists', () => {
+  const prisma = {
+    user: { count: jest.fn() },
+    articleComments: { findMany: jest.fn(), count: jest.fn() },
+    movieScore: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    article: { findMany: jest.fn(), count: jest.fn() },
+  };
+  const service = new UserActivityService(prisma as never);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.user.count.mockResolvedValue(1);
+  });
+
+  it('lists comments with the article they belong to', async () => {
+    prisma.articleComments.findMany.mockResolvedValue([
+      {
+        id: 9,
+        articleId: 3,
+        content: '재밌었어요',
+        createdAt: new Date('2026-08-01T00:00:00Z'),
+        article: { title: '스파이더맨 후기' },
+      },
+    ]);
+    prisma.articleComments.count.mockResolvedValue(11);
+
+    await expect(service.getActivity(4, 'comments', 1, 10)).resolves.toEqual({
+      items: [
+        expect.objectContaining({
+          type: 'comment',
+          id: 9,
+          articleId: 3,
+          articleTitle: '스파이더맨 후기',
+          content: '재밌었어요',
+        }),
+      ],
+      totalCount: 11,
+      hasNext: true,
+    });
+    expect(prisma.articleComments.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userno: 4, deletedAt: null, article: { deletedAt: null } },
+        skip: 0,
+        take: 10,
+      }),
+    );
+  });
+
+  it('lists ratings with movie metadata', async () => {
+    prisma.movieScore.findMany.mockResolvedValue([
+      {
+        movieCd: 20233219,
+        score: 4.5,
+        updatedAt: new Date('2026-08-02T00:00:00Z'),
+        Movie: { title: '스파이더맨', poster: 'poster.jpg' },
+      },
+    ]);
+    prisma.movieScore.count.mockResolvedValue(1);
+
+    const result = await service.getActivity(4, 'ratings', 1, 10);
+
+    expect(result.items[0]).toEqual(
+      expect.objectContaining({
+        type: 'rating',
+        movieCd: 20233219,
+        movieTitle: '스파이더맨',
+        poster: 'poster.jpg',
+        score: 4.5,
+      }),
+    );
+    expect(prisma.movieScore.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { Userno: 4, deletedAt: null } }),
+    );
+  });
+
+  it.each([
+    ['articles', 'article'],
+    ['likes', 'like'],
+  ] as const)(
+    'lists %s by authored article',
+    async (activityType, itemType) => {
+      prisma.article.findMany.mockResolvedValue([
+        {
+          id: 5,
+          title: '내 영화 후기',
+          createdAt: new Date('2026-08-03T00:00:00Z'),
+          like_count: 7,
+          comment_count: 2,
+        },
+      ]);
+      prisma.article.count.mockResolvedValue(1);
+
+      const result = await service.getActivity(4, activityType, 1, 10);
+
+      expect(result.items[0]).toEqual(
+        expect.objectContaining({ type: itemType, articleId: 5, likeCount: 7 }),
+      );
+      expect(prisma.article.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where:
+            activityType === 'likes'
+              ? { userno: 4, deletedAt: null, like_count: { gt: 0 } }
+              : { userno: 4, deletedAt: null },
+        }),
+      );
+    },
+  );
+
+  it('soft deletes only the signed-in user rating', async () => {
+    prisma.movieScore.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(service.deleteRating(4, 20233219)).resolves.toEqual({
+      success: true,
+    });
+    expect(prisma.movieScore.updateMany).toHaveBeenCalledWith({
+      where: { Userno: 4, movieCd: 20233219, deletedAt: null },
+      data: { deletedAt: expect.any(Date) },
+    });
+  });
+
+  it('rejects an unsupported activity type', async () => {
+    await expect(
+      service.getActivity(4, 'unknown' as never, 1, 10),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/apps/api-gateway/src/user/user-activity.controller.spec.ts
+++ b/apps/api-gateway/src/user/user-activity.controller.spec.ts
@@ -3,7 +3,11 @@ import { JwtAuthGuard } from '@app/common/guards/jwtauth/jwtauth.guard';
 import { UserController } from './user.controller';
 
 describe('UserController activity summary', () => {
-  const activityService = { getSummary: jest.fn() };
+  const activityService = {
+    getSummary: jest.fn(),
+    getActivity: jest.fn(),
+    deleteRating: jest.fn(),
+  };
   const controller = new UserController(
     {} as never,
     {} as never,
@@ -28,5 +32,28 @@ describe('UserController activity summary', () => {
     );
 
     expect(guards).toContain(JwtAuthGuard);
+  });
+
+  it('uses the signed-in user for a paged activity list', async () => {
+    activityService.getActivity.mockResolvedValue({ items: [] });
+
+    await controller.getActivity('comments', '2', '5', { user: { userId: 4 } });
+
+    expect(activityService.getActivity).toHaveBeenCalledWith(
+      4,
+      'comments',
+      2,
+      5,
+    );
+  });
+
+  it('uses the signed-in user when deleting a rating', async () => {
+    activityService.deleteRating.mockResolvedValue({ success: true });
+
+    await controller.deleteActivityRating('20233219', {
+      user: { userId: 4 },
+    });
+
+    expect(activityService.deleteRating).toHaveBeenCalledWith(4, 20233219);
   });
 });

--- a/apps/api-gateway/src/user/user-activity.service.ts
+++ b/apps/api-gateway/src/user/user-activity.service.ts
@@ -1,17 +1,22 @@
 import { MySQLPrismaService } from '@app/prisma';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  ActivityPagination,
+  UserActivityPage,
+  UserActivityType,
+} from './user-activity.types';
 
 @Injectable()
 export class UserActivityService {
   constructor(private readonly prisma: MySQLPrismaService) {}
 
   async getSummary(userId: number) {
-    const activeUserCount = await this.prisma.user.count({
-      where: { id: userId, deletedAt: null },
-    });
-    if (activeUserCount === 0) {
-      throw new UnauthorizedException('로그인이 필요합니다.');
-    }
+    await this.assertActiveUser(userId);
 
     const [articleCommentCount, movieRatingCount, articleCount, likes] =
       await Promise.all([
@@ -40,5 +45,155 @@ export class UserActivityService {
       articleCount,
       receivedLikeCount: likes._sum.like_count ?? 0,
     };
+  }
+
+  async getActivity(
+    userId: number,
+    type: UserActivityType,
+    page: number,
+    pageSize: number,
+  ): Promise<UserActivityPage> {
+    await this.assertActiveUser(userId);
+    const pagination = {
+      skip: (Math.max(page, 1) - 1) * Math.min(Math.max(pageSize, 1), 20),
+      take: Math.min(Math.max(pageSize, 1), 20),
+    };
+    if (type === 'comments') return this.getComments(userId, pagination);
+    if (type === 'ratings') return this.getRatings(userId, pagination);
+    if (type === 'articles' || type === 'likes') {
+      return this.getArticles(userId, type, pagination);
+    }
+    throw new BadRequestException('지원하지 않는 활동 유형입니다.');
+  }
+
+  async deleteRating(userId: number, movieCd: number) {
+    await this.assertActiveUser(userId);
+    const result = await this.prisma.movieScore.updateMany({
+      where: { Userno: userId, movieCd, deletedAt: null },
+      data: { deletedAt: new Date() },
+    });
+    if (result.count === 0)
+      throw new NotFoundException('평점을 찾지 못했습니다.');
+    return { success: true };
+  }
+
+  private async getComments(
+    userId: number,
+    pagination: ActivityPagination,
+  ): Promise<UserActivityPage> {
+    const where = {
+      userno: userId,
+      deletedAt: null,
+      article: { deletedAt: null },
+    };
+    const [rows, totalCount] = await Promise.all([
+      this.prisma.articleComments.findMany({
+        where,
+        ...pagination,
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          articleId: true,
+          content: true,
+          createdAt: true,
+          article: { select: { title: true } },
+        },
+      }),
+      this.prisma.articleComments.count({ where }),
+    ]);
+    const items = rows.map((row) => ({
+      type: 'comment' as const,
+      id: row.id,
+      articleId: row.articleId,
+      articleTitle: row.article.title,
+      content: row.content,
+      createdAt: row.createdAt,
+    }));
+    return this.toPage(items, totalCount, pagination);
+  }
+
+  private async getRatings(
+    userId: number,
+    pagination: ActivityPagination,
+  ): Promise<UserActivityPage> {
+    const where = { Userno: userId, deletedAt: null };
+    const [rows, totalCount] = await Promise.all([
+      this.prisma.movieScore.findMany({
+        where,
+        ...pagination,
+        orderBy: { updatedAt: 'desc' },
+        select: {
+          movieCd: true,
+          score: true,
+          updatedAt: true,
+          Movie: { select: { title: true, poster: true } },
+        },
+      }),
+      this.prisma.movieScore.count({ where }),
+    ]);
+    const items = rows.map((row) => ({
+      type: 'rating' as const,
+      movieCd: row.movieCd,
+      movieTitle: row.Movie.title ?? '제목 없음',
+      poster: row.Movie.poster ?? '',
+      score: row.score ?? 0,
+      ratedAt: row.updatedAt,
+    }));
+    return this.toPage(items, totalCount, pagination);
+  }
+
+  private async getArticles(
+    userId: number,
+    type: 'articles' | 'likes',
+    pagination: ActivityPagination,
+  ): Promise<UserActivityPage> {
+    const where = {
+      userno: userId,
+      deletedAt: null,
+      ...(type === 'likes' ? { like_count: { gt: 0 } } : {}),
+    };
+    const [rows, totalCount] = await Promise.all([
+      this.prisma.article.findMany({
+        where,
+        ...pagination,
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          title: true,
+          createdAt: true,
+          like_count: true,
+          comment_count: true,
+        },
+      }),
+      this.prisma.article.count({ where }),
+    ]);
+    const items = rows.map((row) => ({
+      type: type === 'likes' ? ('like' as const) : ('article' as const),
+      articleId: row.id,
+      title: row.title,
+      createdAt: row.createdAt,
+      likeCount: row.like_count,
+      commentCount: row.comment_count,
+    }));
+    return this.toPage(items, totalCount, pagination);
+  }
+
+  private toPage(
+    items: UserActivityPage['items'],
+    totalCount: number,
+    pagination: ActivityPagination,
+  ): UserActivityPage {
+    return {
+      items,
+      totalCount,
+      hasNext: pagination.skip + items.length < totalCount,
+    };
+  }
+
+  private async assertActiveUser(userId: number) {
+    const count = await this.prisma.user.count({
+      where: { id: userId, deletedAt: null },
+    });
+    if (count === 0) throw new UnauthorizedException('로그인이 필요합니다.');
   }
 }

--- a/apps/api-gateway/src/user/user-activity.types.ts
+++ b/apps/api-gateway/src/user/user-activity.types.ts
@@ -1,0 +1,38 @@
+export type UserActivityType = 'comments' | 'ratings' | 'articles' | 'likes';
+
+export interface UserActivityPage {
+  items: UserActivityItem[];
+  totalCount: number;
+  hasNext: boolean;
+}
+
+export type UserActivityItem =
+  | {
+      type: 'comment';
+      id: number;
+      articleId: number;
+      articleTitle: string;
+      content: string;
+      createdAt: Date;
+    }
+  | {
+      type: 'rating';
+      movieCd: number;
+      movieTitle: string;
+      poster: string;
+      score: number;
+      ratedAt: Date;
+    }
+  | {
+      type: 'article' | 'like';
+      articleId: number;
+      title: string;
+      createdAt: Date;
+      likeCount: number;
+      commentCount: number;
+    };
+
+export interface ActivityPagination {
+  skip: number;
+  take: number;
+}

--- a/apps/api-gateway/src/user/user.controller.ts
+++ b/apps/api-gateway/src/user/user.controller.ts
@@ -10,6 +10,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UploadedFiles,
   UseGuards,
@@ -26,6 +27,7 @@ import { convertToUserEntity } from '@app/common/entity';
 import { imageMemoryMulterOptions } from '../upload/image-multer.options';
 import { UploadService } from '../upload/upload.service';
 import { UserActivityService } from './user-activity.service';
+import { UserActivityType } from './user-activity.types';
 
 @Controller('user')
 export class UserController {
@@ -64,6 +66,31 @@ export class UserController {
   @UseGuards(JwtAuthGuard, RateLimitGuard)
   getActivitySummary(@Req() req) {
     return this.userActivityService.getSummary(req.user.userId);
+  }
+
+  @Get('/activity/:type')
+  @UseGuards(JwtAuthGuard, RateLimitGuard)
+  getActivity(
+    @Param('type') type: UserActivityType,
+    @Query('page') page = '1',
+    @Query('pageSize') pageSize = '10',
+    @Req() req,
+  ) {
+    return this.userActivityService.getActivity(
+      req.user.userId,
+      type,
+      Number(page) || 1,
+      Number(pageSize) || 10,
+    );
+  }
+
+  @Delete('/activity/ratings/:movieCd')
+  @UseGuards(JwtAuthGuard, RateLimitGuard)
+  deleteActivityRating(@Param('movieCd') movieCd: string, @Req() req) {
+    return this.userActivityService.deleteRating(
+      req.user.userId,
+      Number(movieCd),
+    );
   }
 
   @Get('/:id')

--- a/apps/movie/src/movie-director-filmography-cache.service.ts
+++ b/apps/movie/src/movie-director-filmography-cache.service.ts
@@ -5,7 +5,7 @@ import { convertMovieDataWithCounts } from './movie.formatter';
 
 const MOVIE_INCLUDE = {
   MovieVod: true,
-  movieScores: true,
+  movieScores: { where: { deletedAt: null } },
   _count: {
     select: {
       Comment: { where: { deletedAt: null } },

--- a/apps/movie/src/movie-director-filmography.service.ts
+++ b/apps/movie/src/movie-director-filmography.service.ts
@@ -9,7 +9,7 @@ import { MoviePosterStorageService } from './movie-poster-storage.service';
 
 const MOVIE_INCLUDE = {
   MovieVod: true,
-  movieScores: true,
+  movieScores: { where: { deletedAt: null } },
   _count: {
     select: {
       Comment: { where: { deletedAt: null } },

--- a/apps/movie/src/movie-read.service.ts
+++ b/apps/movie/src/movie-read.service.ts
@@ -12,7 +12,7 @@ import { MovieDirectorFilmographyCacheService } from './movie-director-filmograp
 
 const MOVIE_INCLUDE = {
   MovieVod: true,
-  movieScores: true,
+  movieScores: { where: { deletedAt: null } },
   _count: {
     select: {
       Comment: { where: { deletedAt: null } },
@@ -81,7 +81,8 @@ export class MovieReadService {
       .slice(0, 10);
   }
 
-  async recommendMovies(_movieCd: number): Promise<any> {
+  async recommendMovies(movieCd: number): Promise<any> {
+    void movieCd;
     // TODO: 벡터 유사도 검색 미구현 — Milvus 또는 pgvector 연동 후 활성화
     return [];
   }

--- a/apps/movie/src/movie-score.service.spec.ts
+++ b/apps/movie/src/movie-score.service.spec.ts
@@ -1,0 +1,64 @@
+import { MovieScoreService } from './movie-score.service';
+
+describe('MovieScoreService soft-deleted ratings', () => {
+  const prisma = {
+    movieScore: {
+      upsert: jest.fn(),
+      findFirst: jest.fn(),
+      aggregate: jest.fn(),
+      count: jest.fn(),
+    },
+  };
+  const utils = { dateToTimestamp: jest.fn(() => ({ seconds: 1 })) };
+  const service = new MovieScoreService(prisma as never, utils as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reactivates a deleted rating when the user scores again', async () => {
+    prisma.movieScore.upsert.mockResolvedValue({
+      id: 1,
+      movieCd: 20233219,
+      Userno: 4,
+      score: 4,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    });
+
+    await service.upsertMovieScore({ movieCd: 20233219, userId: 4, score: 4 });
+
+    expect(prisma.movieScore.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ score: 4, deletedAt: null }),
+      }),
+    );
+  });
+
+  it('reads only an active rating', async () => {
+    prisma.movieScore.findFirst.mockResolvedValue(null);
+
+    await service.getMovieScore({ movieCd: 20233219, userId: 4 });
+
+    expect(prisma.movieScore.findFirst).toHaveBeenCalledWith({
+      where: { movieCd: 20233219, Userno: 4, deletedAt: null },
+    });
+  });
+
+  it('excludes deleted ratings from the average and count', async () => {
+    prisma.movieScore.aggregate.mockResolvedValue({ _avg: { score: 4.5 } });
+    prisma.movieScore.count.mockResolvedValue(2);
+
+    await expect(service.getAverageMovieScore(20233219)).resolves.toEqual({
+      movieCd: 20233219,
+      averageScore: 4.5,
+      scoreCount: 2,
+    });
+    expect(prisma.movieScore.aggregate).toHaveBeenCalledWith({
+      where: { movieCd: 20233219, deletedAt: null },
+      _avg: { score: true },
+    });
+    expect(prisma.movieScore.count).toHaveBeenCalledWith({
+      where: { movieCd: 20233219, deletedAt: null },
+    });
+  });
+});

--- a/apps/movie/src/movie-score.service.ts
+++ b/apps/movie/src/movie-score.service.ts
@@ -23,7 +23,7 @@ export class MovieScoreService {
       where: {
         movieCd_Userno: { movieCd, Userno: userId },
       },
-      update: { score, updatedAt: new Date() },
+      update: { score, deletedAt: null, updatedAt: new Date() },
       create: { movieCd, Userno: userId, score },
     });
 
@@ -32,8 +32,12 @@ export class MovieScoreService {
     return {
       ...movieScore,
       userId: movieScore.Userno,
-      createdAt: this.utilsService.dateToTimestamp(movieScore.createdAt as Date),
-      updatedAt: this.utilsService.dateToTimestamp(movieScore.updatedAt as Date),
+      createdAt: this.utilsService.dateToTimestamp(
+        movieScore.createdAt as Date,
+      ),
+      updatedAt: this.utilsService.dateToTimestamp(
+        movieScore.updatedAt as Date,
+      ),
     } as MovieScore;
   }
 
@@ -44,10 +48,8 @@ export class MovieScoreService {
     movieCd: number;
     userId: number;
   }): Promise<MovieScore> {
-    const movieScore = await this.prisma.movieScore.findUnique({
-      where: {
-        movieCd_Userno: { movieCd, Userno: userId },
-      },
+    const movieScore = await this.prisma.movieScore.findFirst({
+      where: { movieCd, Userno: userId, deletedAt: null },
     });
 
     if (!movieScore) {
@@ -63,14 +65,18 @@ export class MovieScoreService {
     return {
       ...movieScore,
       userId: movieScore.Userno,
-      createdAt: this.utilsService.dateToTimestamp(movieScore.createdAt as Date),
-      updatedAt: this.utilsService.dateToTimestamp(movieScore.updatedAt as Date),
+      createdAt: this.utilsService.dateToTimestamp(
+        movieScore.createdAt as Date,
+      ),
+      updatedAt: this.utilsService.dateToTimestamp(
+        movieScore.updatedAt as Date,
+      ),
     } as MovieScore;
   }
 
   async getAverageMovieScore(movieCd: number): Promise<AverageMovieScore> {
     const aggregate = await this.prisma.movieScore.aggregate({
-      where: { movieCd },
+      where: { movieCd, deletedAt: null },
       _avg: { score: true },
     });
 
@@ -79,7 +85,7 @@ export class MovieScoreService {
     }
 
     const scoreCount = await this.prisma.movieScore.count({
-      where: { movieCd },
+      where: { movieCd, deletedAt: null },
     });
     return {
       movieCd,


### PR DESCRIPTION
## Summary
마이페이지에서 로그인 사용자의 댓글·평점·게시글·받은 좋아요 상세 목록을 조회할 수 있는 API를 추가합니다.
평점 삭제는 soft delete로 처리하고 영화 평균/조회에서는 삭제된 평점을 제외합니다.

## 변경
- 활동 유형별 페이지 조회 API 추가
- 평점 soft delete API 추가
- 삭제 평점 평균 제외 및 재평가 시 복구
- 활동 목록과 평점 동작 테스트 추가

## Test plan
- [x] 변경 파일 ESLint
- [x] 활동 목록·요약·평점 Jest 테스트
- [x] API Gateway 빌드
- [x] Movie 서비스 빌드
- [x] 수정·신규 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)