### PR TITLE
🐛 계정 활동에 영화 댓글 통합

### DIFF
--- a/apps/api-gateway/src/user/user-activity-list.service.spec.ts
+++ b/apps/api-gateway/src/user/user-activity-list.service.spec.ts
@@ -12,45 +12,26 @@ describe('UserActivityService activity lists', () => {
     },
     article: { findMany: jest.fn(), count: jest.fn() },
   };
-  const service = new UserActivityService(prisma as never);
+  const commentActivity = { getPage: jest.fn(), getCount: jest.fn() };
+  const service = new UserActivityService(
+    prisma as never,
+    commentActivity as never,
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
     prisma.user.count.mockResolvedValue(1);
   });
 
-  it('lists comments with the article they belong to', async () => {
-    prisma.articleComments.findMany.mockResolvedValue([
-      {
-        id: 9,
-        articleId: 3,
-        content: '재밌었어요',
-        createdAt: new Date('2026-08-01T00:00:00Z'),
-        article: { title: '스파이더맨 후기' },
-      },
-    ]);
-    prisma.articleComments.count.mockResolvedValue(11);
+  it('delegates comments to the combined comment activity service', async () => {
+    const page = { items: [], totalCount: 0, hasNext: false };
+    commentActivity.getPage.mockResolvedValue(page);
 
-    await expect(service.getActivity(4, 'comments', 1, 10)).resolves.toEqual({
-      items: [
-        expect.objectContaining({
-          type: 'comment',
-          id: 9,
-          articleId: 3,
-          articleTitle: '스파이더맨 후기',
-          content: '재밌었어요',
-        }),
-      ],
-      totalCount: 11,
-      hasNext: true,
+    await expect(service.getActivity(4, 'comments', 1, 10)).resolves.toBe(page);
+    expect(commentActivity.getPage).toHaveBeenCalledWith(4, {
+      skip: 0,
+      take: 10,
     });
-    expect(prisma.articleComments.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { userno: 4, deletedAt: null, article: { deletedAt: null } },
-        skip: 0,
-        take: 10,
-      }),
-    );
   });
 
   it('lists ratings with movie metadata', async () => {

--- a/apps/api-gateway/src/user/user-activity.service.spec.ts
+++ b/apps/api-gateway/src/user/user-activity.service.spec.ts
@@ -11,7 +11,11 @@ describe('UserActivityService', () => {
     },
   };
 
-  const service = new UserActivityService(prisma as never);
+  const commentActivity = { getCount: jest.fn(), getPage: jest.fn() };
+  const service = new UserActivityService(
+    prisma as never,
+    commentActivity as never,
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -19,7 +23,7 @@ describe('UserActivityService', () => {
   });
 
   it('returns the signed-in user community activity summary', async () => {
-    prisma.articleComments.count.mockResolvedValue(7);
+    commentActivity.getCount.mockResolvedValue(7);
     prisma.movieScore.count.mockResolvedValue(4);
     prisma.article.count.mockResolvedValue(2);
     prisma.article.aggregate.mockResolvedValue({ _sum: { like_count: 13 } });
@@ -30,13 +34,7 @@ describe('UserActivityService', () => {
       articleCount: 2,
       receivedLikeCount: 13,
     });
-    expect(prisma.articleComments.count).toHaveBeenCalledWith({
-      where: {
-        userno: 4,
-        deletedAt: null,
-        article: { deletedAt: null },
-      },
-    });
+    expect(commentActivity.getCount).toHaveBeenCalledWith(4);
     expect(prisma.movieScore.count).toHaveBeenCalledWith({
       where: { Userno: 4, deletedAt: null },
     });
@@ -47,7 +45,7 @@ describe('UserActivityService', () => {
   });
 
   it('normalizes an empty received-like sum to zero', async () => {
-    prisma.articleComments.count.mockResolvedValue(0);
+    commentActivity.getCount.mockResolvedValue(0);
     prisma.movieScore.count.mockResolvedValue(0);
     prisma.article.count.mockResolvedValue(0);
     prisma.article.aggregate.mockResolvedValue({ _sum: { like_count: null } });
@@ -61,6 +59,6 @@ describe('UserActivityService', () => {
     prisma.user.count.mockResolvedValue(0);
 
     await expect(service.getSummary(4)).rejects.toThrow('로그인이 필요합니다.');
-    expect(prisma.articleComments.count).not.toHaveBeenCalled();
+    expect(commentActivity.getCount).not.toHaveBeenCalled();
   });
 });

--- a/apps/api-gateway/src/user/user-activity.service.ts
+++ b/apps/api-gateway/src/user/user-activity.service.ts
@@ -10,23 +10,21 @@ import {
   UserActivityPage,
   UserActivityType,
 } from './user-activity.types';
+import { UserCommentActivityService } from './user-comment-activity.service';
 
 @Injectable()
 export class UserActivityService {
-  constructor(private readonly prisma: MySQLPrismaService) {}
+  constructor(
+    private readonly prisma: MySQLPrismaService,
+    private readonly commentActivity: UserCommentActivityService,
+  ) {}
 
   async getSummary(userId: number) {
     await this.assertActiveUser(userId);
 
     const [articleCommentCount, movieRatingCount, articleCount, likes] =
       await Promise.all([
-        this.prisma.articleComments.count({
-          where: {
-            userno: userId,
-            deletedAt: null,
-            article: { deletedAt: null },
-          },
-        }),
+        this.commentActivity.getCount(userId),
         this.prisma.movieScore.count({
           where: { Userno: userId, deletedAt: null },
         }),
@@ -54,11 +52,17 @@ export class UserActivityService {
     pageSize: number,
   ): Promise<UserActivityPage> {
     await this.assertActiveUser(userId);
+    const normalizedPage = Math.max(page, 1);
+    if (normalizedPage > 200) {
+      throw new BadRequestException('조회 가능한 페이지 범위를 초과했습니다.');
+    }
     const pagination = {
-      skip: (Math.max(page, 1) - 1) * Math.min(Math.max(pageSize, 1), 20),
+      skip: (normalizedPage - 1) * Math.min(Math.max(pageSize, 1), 20),
       take: Math.min(Math.max(pageSize, 1), 20),
     };
-    if (type === 'comments') return this.getComments(userId, pagination);
+    if (type === 'comments') {
+      return this.commentActivity.getPage(userId, pagination);
+    }
     if (type === 'ratings') return this.getRatings(userId, pagination);
     if (type === 'articles' || type === 'likes') {
       return this.getArticles(userId, type, pagination);
@@ -75,41 +79,6 @@ export class UserActivityService {
     if (result.count === 0)
       throw new NotFoundException('평점을 찾지 못했습니다.');
     return { success: true };
-  }
-
-  private async getComments(
-    userId: number,
-    pagination: ActivityPagination,
-  ): Promise<UserActivityPage> {
-    const where = {
-      userno: userId,
-      deletedAt: null,
-      article: { deletedAt: null },
-    };
-    const [rows, totalCount] = await Promise.all([
-      this.prisma.articleComments.findMany({
-        where,
-        ...pagination,
-        orderBy: { createdAt: 'desc' },
-        select: {
-          id: true,
-          articleId: true,
-          content: true,
-          createdAt: true,
-          article: { select: { title: true } },
-        },
-      }),
-      this.prisma.articleComments.count({ where }),
-    ]);
-    const items = rows.map((row) => ({
-      type: 'comment' as const,
-      id: row.id,
-      articleId: row.articleId,
-      articleTitle: row.article.title,
-      content: row.content,
-      createdAt: row.createdAt,
-    }));
-    return this.toPage(items, totalCount, pagination);
   }
 
   private async getRatings(

--- a/apps/api-gateway/src/user/user-activity.types.ts
+++ b/apps/api-gateway/src/user/user-activity.types.ts
@@ -10,8 +10,9 @@ export type UserActivityItem =
   | {
       type: 'comment';
       id: number;
-      articleId: number;
-      articleTitle: string;
+      targetType: 'movie' | 'article';
+      targetId: number;
+      targetTitle: string;
       content: string;
       createdAt: Date;
     }

--- a/apps/api-gateway/src/user/user-comment-activity.service.spec.ts
+++ b/apps/api-gateway/src/user/user-comment-activity.service.spec.ts
@@ -1,0 +1,58 @@
+import { UserCommentActivityService } from './user-comment-activity.service';
+
+describe('UserCommentActivityService', () => {
+  const prisma = {
+    comment: { findMany: jest.fn(), count: jest.fn() },
+    articleComments: { findMany: jest.fn(), count: jest.fn() },
+  };
+  const service = new UserCommentActivityService(prisma as never);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('combines movie and article comments in newest-first order', async () => {
+    prisma.comment.findMany.mockResolvedValue([
+      {
+        id: 12,
+        movieId: 20262770,
+        comment: '영화 댓글',
+        createdAt: new Date('2026-08-04T12:00:00Z'),
+        Movie: { title: '신작 영화' },
+      },
+    ]);
+    prisma.articleComments.findMany.mockResolvedValue([
+      {
+        id: 7,
+        articleId: 5,
+        content: '게시글 댓글',
+        createdAt: new Date('2026-08-03T12:00:00Z'),
+        article: { title: '영화 후기' },
+      },
+    ]);
+    prisma.comment.count.mockResolvedValue(1);
+    prisma.articleComments.count.mockResolvedValue(1);
+
+    await expect(service.getPage(4, { skip: 0, take: 10 })).resolves.toEqual({
+      items: [
+        expect.objectContaining({
+          targetType: 'movie',
+          targetId: 20262770,
+          targetTitle: '신작 영화',
+        }),
+        expect.objectContaining({
+          targetType: 'article',
+          targetId: 5,
+          targetTitle: '영화 후기',
+        }),
+      ],
+      totalCount: 2,
+      hasNext: false,
+    });
+  });
+
+  it('counts comments from both sources', async () => {
+    prisma.comment.count.mockResolvedValue(3);
+    prisma.articleComments.count.mockResolvedValue(4);
+
+    await expect(service.getCount(4)).resolves.toBe(7);
+  });
+});

--- a/apps/api-gateway/src/user/user-comment-activity.service.ts
+++ b/apps/api-gateway/src/user/user-comment-activity.service.ts
@@ -1,0 +1,123 @@
+import { MySQLPrismaService } from '@app/prisma';
+import { Injectable } from '@nestjs/common';
+import { ActivityPagination, UserActivityPage } from './user-activity.types';
+
+type MovieCommentRow = {
+  id: number;
+  movieId: number;
+  comment: string | null;
+  createdAt: Date;
+  Movie: { title: string | null };
+};
+
+type ArticleCommentRow = {
+  id: number;
+  articleId: number;
+  content: string;
+  createdAt: Date;
+  article: { title: string };
+};
+
+type CommentActivityDelegate<Row> = {
+  count(args: unknown): Promise<number>;
+  findMany(args: unknown): Promise<Row[]>;
+};
+
+@Injectable()
+export class UserCommentActivityService {
+  constructor(private readonly prisma: MySQLPrismaService) {}
+
+  private get movieComments(): CommentActivityDelegate<MovieCommentRow> {
+    return this.prisma
+      .comment as unknown as CommentActivityDelegate<MovieCommentRow>;
+  }
+
+  private get articleComments(): CommentActivityDelegate<ArticleCommentRow> {
+    return this.prisma
+      .articleComments as unknown as CommentActivityDelegate<ArticleCommentRow>;
+  }
+
+  async getCount(userId: number): Promise<number> {
+    const [movieCount, articleCount] = await Promise.all([
+      this.movieComments.count({ where: { userno: userId, deletedAt: null } }),
+      this.articleComments.count({
+        where: {
+          userno: userId,
+          deletedAt: null,
+          article: { deletedAt: null },
+        },
+      }),
+    ]);
+    return movieCount + articleCount;
+  }
+
+  async getPage(
+    userId: number,
+    pagination: ActivityPagination,
+  ): Promise<UserActivityPage> {
+    const take = pagination.skip + pagination.take;
+    const articleWhere = {
+      userno: userId,
+      deletedAt: null,
+      article: { deletedAt: null },
+    };
+    const [movies, articles, movieCount, articleCount] = await Promise.all([
+      this.movieComments.findMany({
+        where: { userno: userId, deletedAt: null },
+        take,
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          movieId: true,
+          comment: true,
+          createdAt: true,
+          Movie: { select: { title: true } },
+        },
+      }),
+      this.articleComments.findMany({
+        where: articleWhere,
+        take,
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          articleId: true,
+          content: true,
+          createdAt: true,
+          article: { select: { title: true } },
+        },
+      }),
+      this.movieComments.count({
+        where: { userno: userId, deletedAt: null },
+      }),
+      this.articleComments.count({ where: articleWhere }),
+    ]);
+    const totalCount = movieCount + articleCount;
+    const items: UserActivityPage['items'] = [
+      ...movies.map((row) => ({
+        type: 'comment' as const,
+        id: row.id,
+        targetType: 'movie' as const,
+        targetId: row.movieId,
+        targetTitle: row.Movie.title ?? '제목 없음',
+        content: row.comment ?? '',
+        createdAt: row.createdAt,
+      })),
+      ...articles.map((row) => ({
+        type: 'comment' as const,
+        id: row.id,
+        targetType: 'article' as const,
+        targetId: row.articleId,
+        targetTitle: row.article.title,
+        content: row.content,
+        createdAt: row.createdAt,
+      })),
+    ]
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice(pagination.skip, pagination.skip + pagination.take);
+    return {
+      items,
+      totalCount,
+      hasNext: pagination.skip + items.length < totalCount,
+    };
+  }
+}

--- a/apps/api-gateway/src/user/user.module.ts
+++ b/apps/api-gateway/src/user/user.module.ts
@@ -7,6 +7,7 @@ import { UserController } from './user.controller';
 import { UploadModule } from '../upload/upload.module';
 import { PrismaModule } from '@app/prisma';
 import { UserActivityService } from './user-activity.service';
+import { UserCommentActivityService } from './user-comment-activity.service';
 @Module({
   imports: [
     UploadModule,
@@ -24,6 +25,6 @@ import { UserActivityService } from './user-activity.service';
     ]),
   ],
   controllers: [UserController],
-  providers: [UserService, UserActivityService],
+  providers: [UserService, UserActivityService, UserCommentActivityService],
 })
 export class UserModule {}


### PR DESCRIPTION
## Summary
계정 활동의 작성 댓글 목록과 요약에 영화 댓글을 함께 제공합니다.

## 원인
기존 활동 API가 articleComments만 조회해 영화 상세에 작성한 댓글이 누락됐습니다.

## 변경
- 영화 댓글과 게시글 댓글을 최신순으로 통합 조회
- 각 댓글에 대상 유형·ID·제목 반환
- 요약 댓글 수에 두 댓글 소스 반영
- 과도한 페이지 번호 요청 제한

## Test plan
- [x] 관련 Jest 15개 통과
- [x] 변경 파일 ESLint 통과
- [x] `pnpm build api-gateway` 성공
- [x] 변경 파일 200줄 상한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)